### PR TITLE
Fix wild level-up moves of alternate forms

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3172,6 +3172,7 @@ void __attribute__((long_call)) UpdatePassiveForms(struct PartyPokemon *pp)
 {
     u32 species = GetMonData(pp, ID_PARA_monsno, NULL);
     u32 form = 0;
+    BOOL shouldUpdate = TRUE;
     
     switch (species)
     {
@@ -3189,9 +3190,13 @@ void __attribute__((long_call)) UpdatePassiveForms(struct PartyPokemon *pp)
         case SPECIES_PYROAR:
             form = (gf_rand() % 8 != 0); // 1/8 male
             break;
+        default:
+            shouldUpdate = FALSE;
     }
 
-    SetMonData(pp, ID_PARA_form_no, &form);
+    if (shouldUpdate) {
+        SetMonData(pp, ID_PARA_form_no, &form);
+    }
 }
 
 BOOL __attribute__((long_call)) Party_UpdateDeerlingSeasonForm(struct Party *party)
@@ -3908,6 +3913,14 @@ void __attribute__((long_call)) CreateBoxMonData(struct BoxPokemon *boxmon, int 
     }
     else if(idflag!=ID_SET){
         id=0;
+    }
+
+    // this function or AddWildPartyPokemon could both get here first
+    // and since both functions will initialize the moveset,
+    // we need the form to be set correctly in either case
+    if (space_for_setmondata != 0)
+    {
+        BoxMonDataSet(boxmon, ID_PARA_form_no, (u8 *)&space_for_setmondata);
     }
 
     BoxMonDataSet(boxmon,ID_PARA_id_no,(u8 *)&id);


### PR DESCRIPTION
I have not tested this in HG, but in Pt there is an issue with wild alternate forms, which is that they get moves from both the base form and the alternate form learnset.

The reason is that, at least in Pt, in most cases (unless, I think, Cute Charm is present) CreateBoxMonData is called before AddWildPartyPokemon. So CreateMonBoxData initializes the moveset with original form moves, form is set in AddWildPartyPokemon, which then overrides the moves with the alternate form learnset. But if the alternate form doesn't have 4 moves to learn, the base form moves are still there. For example, wild lv3 Alolan Vulpix has both Ember and Powder Snow.

This was made worse by https://github.com/BluRosie/hg-engine/commit/b9389299ace40ab204677051512a7855223930df, which now sets the form to 0 for all mons besides those listed in the function. This means the form set here is immediately overridden: https://github.com/BluRosie/hg-engine/blob/b9389299ace40ab204677051512a7855223930df/asm/other_hook.s#L222-L231 and so the base form moveset is initialized AFTER the alternate form (meaning it will always be used --> A-Vulpix always has normal Vulpix's moves).

These changes fix the issue in Pt --> wild lv3 Alolan Vulpix has only Powder Snow and Tail Whip, as expected. Again, have not tested in HG, I think these changes should be safe though?