### PR TITLE
Fix for Beast boost

### DIFF
--- a/src/battle/ability.c
+++ b/src/battle/ability.c
@@ -1455,7 +1455,7 @@ u8 BeastBoostGreatestStatHelper(struct BattleStruct *sp, u32 client)
     for(u8 i = 0; i < NELEMS(stats); i++)
     {
         if(stats[i] > max)
-            max = i;
+            max = stats[i];
     }
 
     return max;

--- a/src/battle/ability.c
+++ b/src/battle/ability.c
@@ -1452,13 +1452,15 @@ u8 BeastBoostGreatestStatHelper(struct BattleStruct *sp, u32 client)
     };
 
     u8 max = 0;
+    u8 ret = 0;
     for(u8 i = 0; i < NELEMS(stats); i++)
     {
         if(stats[i] > max)
             max = stats[i];
+            ret = i;
     }
 
-    return max;
+    return ret;
 }
 
 


### PR DESCRIPTION
Max was being set to i instead of the actual max value

Added an extra var to store both the return and the max value

Not the cleanest way to do it maybe.