### PR TITLE
Implement Field Use of Mirror Herb and Pokémon Nursery Mechanics

### DIFF
--- a/hooks
+++ b/hooks
@@ -433,3 +433,5 @@ arm9 MonTryLearnMoveOnLevelUp 02071534 3
 
 # edit the playcry command to potentially take form into account
 0007 AnimCmd_PlayCryEdit_hook 0221F854 0
+
+arm9 ScrCmd_DaycareSanitizeMon 0204CFB8 1

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -897,7 +897,7 @@ void  LONG_CALL SetBoxMonData(struct BoxPokemon *boxmon, int id, const void *buf
  *  @param pos position to grab
  *  @return PartyPokemon requested
  */
-struct PartyPokemon * LONG_CALL PokeParty_GetMemberPointer(struct Party *party, int pos);
+struct PartyPokemon * LONG_CALL Party_GetMonByIndex(struct Party *party, int pos);
 
 /**
  *  @brief grab personal field accounting for form (for vanilla forms)
@@ -1757,9 +1757,6 @@ u32 LONG_CALL GenerateShinyPIDKeepSubstructuresIntact(u32 otId, u32 pid);
  *  @return requested data
  */
 u32 LONG_CALL GetMoveData(u16 id, u32 field);
-
-
-struct PartyPokemon LONG_CALL *Party_GetMonByIndex(struct Party *party, int slot);
 
 BOOL LONG_CALL Mon_UpdateRotomForm(struct PartyPokemon *mon, int form, int defaultSlot);
 

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -1759,6 +1759,12 @@ u32 LONG_CALL GenerateShinyPIDKeepSubstructuresIntact(u32 otId, u32 pid);
 u32 LONG_CALL GetMoveData(u16 id, u32 field);
 
 
+struct PartyPokemon LONG_CALL *Party_GetMonByIndex(struct Party *party, int slot);
 
+BOOL LONG_CALL Mon_UpdateRotomForm(struct PartyPokemon *mon, int form, int defaultSlot);
+
+void LONG_CALL Mon_UpdateShayminForm(struct PartyPokemon *mon, int form);
+
+void LONG_CALL Daycare_GetBothBoxMonsPtr(Daycare *dayCare, struct BoxPokemon **boxmons);
 
 #endif

--- a/rom.ld
+++ b/rom.ld
@@ -261,7 +261,7 @@ CT_PokemonAppearSet = 0x02259D48 | 1;
 ClientCommandReset = 0x02259928 | 1;
 BattleWorkPokePartyGet = 0x0223A7F4 | 1;
 PokeParty_GetPokeCount = 0x02074640 | 1;
-PokeParty_GetMemberPointer = 0x02074644 | 1;
+Party_GetMonByIndex = 0x02074644 | 1;
 SideClientNoGet = 0x0224768C | 1;
 BattleWorkClientNoGet = 0x0223AAD8 | 1;
 BattleWorkPartnerClientNoGet = 0x0223AB6C | 1;
@@ -584,8 +584,6 @@ TryAppendMonMove = 0x0207137C | 1;
 
 BattleControllerPlayer_CalcExecutionOrder = 0x02249190 | 1;
 
-Party_GetMonByIndex = 0x02074644 | 1;
 Mon_UpdateRotomForm = 0x02071EC0 | 1;
 Mon_UpdateShayminForm = 0x02071D6C | 1;
 Daycare_GetBothBoxMonsPtr = 0x0206C1C8 | 1;
-

--- a/rom.ld
+++ b/rom.ld
@@ -583,3 +583,9 @@ LoadLevelUpLearnset_HandleAlternateForm = 0x02071FC8 | 1;
 TryAppendMonMove = 0x0207137C | 1;
 
 BattleControllerPlayer_CalcExecutionOrder = 0x02249190 | 1;
+
+Party_GetMonByIndex = 0x02074644 | 1;
+Mon_UpdateRotomForm = 0x02071EC0 | 1;
+Mon_UpdateShayminForm = 0x02071D6C | 1;
+Daycare_GetBothBoxMonsPtr = 0x0206C1C8 | 1;
+

--- a/src/battle/battle_pokemon.c
+++ b/src/battle/battle_pokemon.c
@@ -448,7 +448,7 @@ BOOL BattleFormChangeCheck(void *bw, struct BattleStruct *sp, int *seq_no)
          && gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, sp->client_work)] == sp->sel_mons_no[sp->client_work]
          && (sp->oneSelfFlag[sp->client_work].physical_damage || sp->oneSelfFlag[sp->client_work].special_damage))
         {
-            SetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, sp->client_work), gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, sp->client_work)]), MON_DATA_NICKNAME, gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, sp->client_work)]);
+            SetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, sp->client_work), gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, sp->client_work)]), MON_DATA_NICKNAME, gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, sp->client_work)]);
 
             gIllusionStruct.isSideInIllusion &= ~No2Bit(SanitizeClientForTeamAccess(bw, sp->client_work));
             gIllusionStruct.illusionClient[SanitizeClientForTeamAccess(bw, sp->client_work)] = CLIENT_MAX;
@@ -573,7 +573,7 @@ void ClientPokemonEncount(void *bw, struct CLIENT_PARAM *cp)
 
     if (
     // mon's ability is illusion
-         GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), 0), MON_DATA_ABILITY, 0) == ABILITY_ILLUSION
+         GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), 0), MON_DATA_ABILITY, 0) == ABILITY_ILLUSION
     // illusion position is not initialized or has been initialized to the current position
      && (gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] == 6 || gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] == 0)
     // if a side has 2 battlers, the logic can run regardless--the "last mon" is worst-case the one being sent out so nothing changes
@@ -585,9 +585,9 @@ void ClientPokemonEncount(void *bw, struct CLIENT_PARAM *cp)
     {
         u16 strbuf[11];
 
-        newmon = GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_SPECIES, NULL);
-        newform = GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_FORM, NULL);
-        newshiny = MonIsShiny(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1));
+        newmon = GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_SPECIES, NULL);
+        newform = GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_FORM, NULL);
+        newshiny = MonIsShiny(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1));
 
         if (newmon != pep->monsno || newform != pep->form_no)
         {
@@ -599,11 +599,11 @@ void ClientPokemonEncount(void *bw, struct CLIENT_PARAM *cp)
             if (!(gIllusionStruct.isSideInIllusion & No2Bit(SanitizeClientForTeamAccess(bw, side))))
             {
                 gIllusionStruct.isSideInIllusion |= No2Bit(SanitizeClientForTeamAccess(bw, side));
-                GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_NICKNAME, strbuf);
-                GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), 0), MON_DATA_NICKNAME, gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, side)]);
+                GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_NICKNAME, strbuf);
+                GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), 0), MON_DATA_NICKNAME, gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, side)]);
                 gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] = 0;
 
-                SetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), 0), MON_DATA_NICKNAME, strbuf);
+                SetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), 0), MON_DATA_NICKNAME, strbuf);
             }
         }
     }
@@ -628,7 +628,7 @@ void ClientPokemonEncountAppear(void *bw, struct CLIENT_PARAM *cp)
 
     if (
     // mon's ability is illusion
-         GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_ABILITY, 0) == ABILITY_ILLUSION
+         GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_ABILITY, 0) == ABILITY_ILLUSION
     // illusion position is not initialized or has been initialized to the current position
      && (gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] == 6 || gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] == pap->sel_mons_no)
     // if a side has 2 battlers, the logic can run regardless--the "last mon" worst-case is the one being sent out so nothing changes
@@ -640,9 +640,9 @@ void ClientPokemonEncountAppear(void *bw, struct CLIENT_PARAM *cp)
     {
         u16 strbuf[11];
 
-        newmon = GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_SPECIES, NULL);
-        newform = GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_FORM, NULL);
-        newshiny = MonIsShiny(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1));
+        newmon = GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_SPECIES, NULL);
+        newform = GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_FORM, NULL);
+        newshiny = MonIsShiny(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1));
 
         if (newmon != pap->monsno || newform != pap->form_no)
         {
@@ -654,11 +654,11 @@ void ClientPokemonEncountAppear(void *bw, struct CLIENT_PARAM *cp)
             if (!(gIllusionStruct.isSideInIllusion & No2Bit(SanitizeClientForTeamAccess(bw, side))))
             {
                 gIllusionStruct.isSideInIllusion |= No2Bit(SanitizeClientForTeamAccess(bw, side));
-                GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_NICKNAME, strbuf);
-                GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_NICKNAME, gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, side)]);
+                GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_NICKNAME, strbuf);
+                GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_NICKNAME, gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, side)]);
                 gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] = pap->sel_mons_no;
 
-                SetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_NICKNAME, strbuf);
+                SetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_NICKNAME, strbuf);
             }
         }
     }
@@ -683,7 +683,7 @@ void ClientPokemonAppear(void *bw, struct CLIENT_PARAM *cp)
 
     if (
     // mon's ability is illusion
-         GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_ABILITY, 0) == ABILITY_ILLUSION
+         GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_ABILITY, 0) == ABILITY_ILLUSION
     // illusion position is not initialized or has been initialized to the current position
      && (gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] == 6 || gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] == pap->sel_mons_no)
     // if a side has 2 battlers, the logic can run regardless--the "last mon" is worst-case the one being sent out so nothing changes
@@ -695,9 +695,9 @@ void ClientPokemonAppear(void *bw, struct CLIENT_PARAM *cp)
     {
         u16 strbuf[11];
 
-        newmon = GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_SPECIES, NULL);
-        newform = GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_FORM, NULL);
-        newshiny = MonIsShiny(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1));
+        newmon = GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_SPECIES, NULL);
+        newform = GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_FORM, NULL);
+        newshiny = MonIsShiny(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1));
 
         if (newmon != pap->monsno || newform != pap->form_no)
         {
@@ -709,11 +709,11 @@ void ClientPokemonAppear(void *bw, struct CLIENT_PARAM *cp)
             if (!(gIllusionStruct.isSideInIllusion & No2Bit(SanitizeClientForTeamAccess(bw, side))))
             {
                 gIllusionStruct.isSideInIllusion |= No2Bit(SanitizeClientForTeamAccess(bw, side));
-                GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_NICKNAME, strbuf);
-                GetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_NICKNAME, gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, side)]);
+                GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), count - 1), MON_DATA_NICKNAME, strbuf);
+                GetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_NICKNAME, gIllusionStruct.illusionNameBuf[SanitizeClientForTeamAccess(bw, side)]);
                 gIllusionStruct.illusionPos[SanitizeClientForTeamAccess(bw, side)] = pap->sel_mons_no;
 
-                SetMonData(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_NICKNAME, strbuf);
+                SetMonData(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, side), pap->sel_mons_no), MON_DATA_NICKNAME, strbuf);
             }
         }
     }
@@ -781,7 +781,7 @@ void CT_SwitchInMessageParamMake(void *bw, struct CLIENT_PARAM *cp, struct SWITC
 
         party = BattleWorkPokePartyGet(bw, cp->client_no);
 
-        ability = GetMonData(PokeParty_GetMemberPointer(party, smp->sel_mons_no), MON_DATA_ABILITY, NULL);
+        ability = GetMonData(Party_GetMonByIndex(party, smp->sel_mons_no), MON_DATA_ABILITY, NULL);
 
         // switch in we do not need to check for if the client is actually in an illusion
         if (ability == ABILITY_ILLUSION
@@ -816,7 +816,7 @@ void CT_SwitchInMessageParamMake(void *bw, struct CLIENT_PARAM *cp, struct SWITC
 
         party = BattleWorkPokePartyGet(bw, cp->client_no);
 
-        ability = GetMonData(PokeParty_GetMemberPointer(party, smp->sel_mons_no), MON_DATA_ABILITY, NULL);
+        ability = GetMonData(Party_GetMonByIndex(party, smp->sel_mons_no), MON_DATA_ABILITY, NULL);
         if (ability == ABILITY_ILLUSION
          && ((DoesSideHave2Battlers(bw, cp->client_no))
           || (BattleTypeGet(bw) & (BATTLE_TYPE_MULTI | BATTLE_TYPE_DOUBLE) && party->count > 2)
@@ -894,7 +894,7 @@ void CT_EncountSendOutMessageParamMake(void *bw, struct CLIENT_PARAM *cp, struct
 
             party = BattleWorkPokePartyGet(bw, client1);
 
-            ability = GetMonData(PokeParty_GetMemberPointer(party, esomp->sel_mons_no[client1]), MON_DATA_ABILITY, NULL);
+            ability = GetMonData(Party_GetMonByIndex(party, esomp->sel_mons_no[client1]), MON_DATA_ABILITY, NULL);
             if (ability == ABILITY_ILLUSION
              && ((DoesSideHave2Battlers(bw, cp->client_no))
               || (BattleTypeGet(bw) & (BATTLE_TYPE_MULTI | BATTLE_TYPE_DOUBLE) && party->count > 2)
@@ -913,7 +913,7 @@ void CT_EncountSendOutMessageParamMake(void *bw, struct CLIENT_PARAM *cp, struct
 
             party = BattleWorkPokePartyGet(bw, client2);
 
-            ability = GetMonData(PokeParty_GetMemberPointer(party, esomp->sel_mons_no[client2]), MON_DATA_ABILITY, NULL);
+            ability = GetMonData(Party_GetMonByIndex(party, esomp->sel_mons_no[client2]), MON_DATA_ABILITY, NULL);
             if (ability == ABILITY_ILLUSION
              && ((DoesSideHave2Battlers(bw, cp->client_no))
               || (BattleTypeGet(bw) & (BATTLE_TYPE_MULTI | BATTLE_TYPE_DOUBLE) && party->count > 2)
@@ -1052,7 +1052,7 @@ void CT_EncountSendOutMessageParamMake(void *bw, struct CLIENT_PARAM *cp, struct
 
             party = BattleWorkPokePartyGet(bw, client1);
 
-            ability = GetMonData(PokeParty_GetMemberPointer(party, esomp->sel_mons_no[client1]), MON_DATA_ABILITY, NULL);
+            ability = GetMonData(Party_GetMonByIndex(party, esomp->sel_mons_no[client1]), MON_DATA_ABILITY, NULL);
             if (ability == ABILITY_ILLUSION
              && ((DoesSideHave2Battlers(bw, cp->client_no))
               || (BattleTypeGet(bw) & (BATTLE_TYPE_MULTI | BATTLE_TYPE_DOUBLE) && party->count > 2)
@@ -1071,7 +1071,7 @@ void CT_EncountSendOutMessageParamMake(void *bw, struct CLIENT_PARAM *cp, struct
 
             party = BattleWorkPokePartyGet(bw, client2);
 
-            ability = GetMonData(PokeParty_GetMemberPointer(party, esomp->sel_mons_no[client2]), MON_DATA_ABILITY, NULL);
+            ability = GetMonData(Party_GetMonByIndex(party, esomp->sel_mons_no[client2]), MON_DATA_ABILITY, NULL);
             if (ability == ABILITY_ILLUSION
              && ((DoesSideHave2Battlers(bw, cp->client_no))
               || (BattleTypeGet(bw) & (BATTLE_TYPE_MULTI | BATTLE_TYPE_DOUBLE) && party->count > 2)

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -1071,7 +1071,7 @@ int CalcCritical(void *bw, struct BattleStruct *sp, int attacker, int defender, 
         sp->battlemon[attacker].critical_hits++;
         if (sp->battlemon[attacker].critical_hits == 3)
         {
-            SET_MON_CRITICAL_HIT_EVOLUTION_BIT(PokeParty_GetMemberPointer(BattleWorkPokePartyGet(bw, attacker), sp->sel_mons_no[attacker]));
+            SET_MON_CRITICAL_HIT_EVOLUTION_BIT(Party_GetMonByIndex(BattleWorkPokePartyGet(bw, attacker), sp->sel_mons_no[attacker]));
         }
     }
 

--- a/src/field/enemy_party.c
+++ b/src/field/enemy_party.c
@@ -439,7 +439,7 @@ void MakeTrainerPokemonParty(struct BATTLE_PARAM *bp, int num, int heapID)
             {
                 for(j = 0; j < 4; j++)
                 {
-                    SetMonData(mons[i],MON_DATA_MOVE1PPUP+j, &ppcounts[j]);
+                    SetMonData(mons[i],MON_DATA_MOVE1PP+j, &ppcounts[j]);
                 }
             }
             if (additionalflags & TRAINER_DATA_EXTRA_TYPE_NICKNAME)

--- a/src/field/script_commands.c
+++ b/src/field/script_commands.c
@@ -181,8 +181,8 @@ BOOL ScrCmd_DaycareSanitizeMon(SCRIPTCONTEXT *ctx) {
     if (GetBoxMonData(daycareMon, MON_DATA_SPECIES, NULL) != SPECIES_NONE) {
         u32 inheriterMoves[4];
         u32 donorMoves[4];
-        u16 temp_egg_moves[16];
-        u16 baby_egg_moves[16];
+        u16 temp_egg_moves[EGG_MOVES_PER_MON];
+        u16 baby_egg_moves[EGG_MOVES_PER_MON];
         u8 potentialOverrideMoveSlot;
         u8 numEggMoves;
         u32 newMove;

--- a/src/field/script_commands.c
+++ b/src/field/script_commands.c
@@ -230,16 +230,21 @@ BOOL ScrCmd_DaycareSanitizeMon(SCRIPTCONTEXT *ctx) {
                 donorMoves[2] = GetBoxMonData(daycareMon, MON_DATA_MOVE3, NULL);
                 donorMoves[3] = GetBoxMonData(daycareMon, MON_DATA_MOVE4, NULL);
 
-                for (u8 i = 0; i < numAvailableToInheritMoves; i++) {
-                    if (donorMoves[0] == baby_egg_moves[i] || donorMoves[1] == baby_egg_moves[i] || donorMoves[2] == baby_egg_moves[i] || donorMoves[3] == baby_egg_moves[i]) {
-                        newMove = baby_egg_moves[i];
-                        SetMonData(partyMon, MON_DATA_MOVE1 + potentialOverrideMoveSlot, &newMove);
-                        pp = GetMonData(partyMon, MON_DATA_MOVE1MAXPP + potentialOverrideMoveSlot, NULL);
-                        SetMonData(partyMon, MON_DATA_MOVE1PP + potentialOverrideMoveSlot, &pp);
-                        potentialOverrideMoveSlot++;
-                        if (potentialOverrideMoveSlot >= 4) {
-                            break;
+                for (u8 i = 0; i < 4; i++) {
+                    for (u8 j = 0; j < numAvailableToInheritMoves; j++) {
+                        if (donorMoves[i] == baby_egg_moves[j]) {
+                            newMove = baby_egg_moves[j];
+                            SetMonData(partyMon, MON_DATA_MOVE1 + potentialOverrideMoveSlot, &newMove);
+                            pp = GetMonData(partyMon, MON_DATA_MOVE1MAXPP + potentialOverrideMoveSlot, NULL);
+                            SetMonData(partyMon, MON_DATA_MOVE1PP + potentialOverrideMoveSlot, &pp);
+                            potentialOverrideMoveSlot++;
+                            if (potentialOverrideMoveSlot >= 4) {
+                                break;
+                            }
                         }
+                    }
+                    if (potentialOverrideMoveSlot >= 4) {
+                        break;
                     }
                 }
             }
@@ -290,16 +295,21 @@ BOOL ScrCmd_DaycareSanitizeMon(SCRIPTCONTEXT *ctx) {
                 donorMoves[2] = GetMonData(partyMon, MON_DATA_MOVE3, NULL);
                 donorMoves[3] = GetMonData(partyMon, MON_DATA_MOVE4, NULL);
 
-                for (u8 i = 0; i < numAvailableToInheritMoves; i++) {
-                    if (donorMoves[0] == baby_egg_moves[i] || donorMoves[1] == baby_egg_moves[i] || donorMoves[2] == baby_egg_moves[i] || donorMoves[3] == baby_egg_moves[i]) {
-                        newMove = baby_egg_moves[i];
-                        SetBoxMonData(daycareMon, MON_DATA_MOVE1 + potentialOverrideMoveSlot, &newMove);
-                        pp = GetBoxMonData(daycareMon, MON_DATA_MOVE1MAXPP + potentialOverrideMoveSlot, NULL);
-                        SetBoxMonData(daycareMon, MON_DATA_MOVE1PP + potentialOverrideMoveSlot, &pp);
-                        potentialOverrideMoveSlot++;
-                        if (potentialOverrideMoveSlot >= 4) {
-                            break;
+                for (u8 i = 0; i < 4; i++) {
+                    for (u8 j = 0; j < numAvailableToInheritMoves; j++) {
+                        if (donorMoves[i] == baby_egg_moves[j]) {
+                            newMove = baby_egg_moves[j];
+                            SetBoxMonData(daycareMon, MON_DATA_MOVE1 + potentialOverrideMoveSlot, &newMove);
+                            pp = GetBoxMonData(daycareMon, MON_DATA_MOVE1MAXPP + potentialOverrideMoveSlot, NULL);
+                            SetBoxMonData(daycareMon, MON_DATA_MOVE1PP + potentialOverrideMoveSlot, &pp);
+                            potentialOverrideMoveSlot++;
+                            if (potentialOverrideMoveSlot >= 4) {
+                                break;
+                            }
                         }
+                    }
+                    if (potentialOverrideMoveSlot >= 4) {
+                        break;
                     }
                 }
             }

--- a/src/field/script_commands.c
+++ b/src/field/script_commands.c
@@ -187,7 +187,7 @@ BOOL ScrCmd_DaycareSanitizeMon(SCRIPTCONTEXT *ctx) {
         u8 numEggMoves;
         u32 newMove;
         u32 pp;
-        u8 buf[64];
+        // u8 buf[64];
 
         // Begin custom logic for Mirror Herb
         if (GetMonData(partyMon, MON_DATA_HELD_ITEM, NULL) == ITEM_MIRROR_HERB || GetMonData(partyMon, MON_DATA_SPECIES, NULL) == GetBoxMonData(daycareMon, MON_DATA_SPECIES, NULL)) {
@@ -236,7 +236,10 @@ BOOL ScrCmd_DaycareSanitizeMon(SCRIPTCONTEXT *ctx) {
                         SetMonData(partyMon, MON_DATA_MOVE1 + potentialOverrideMoveSlot, &newMove);
                         pp = GetMonData(partyMon, MON_DATA_MOVE1MAXPP + potentialOverrideMoveSlot, NULL);
                         SetMonData(partyMon, MON_DATA_MOVE1PP + potentialOverrideMoveSlot, &pp);
-                        break;
+                        potentialOverrideMoveSlot++;
+                        if (potentialOverrideMoveSlot >= 4) {
+                            break;
+                        }
                     }
                 }
             }
@@ -293,7 +296,10 @@ BOOL ScrCmd_DaycareSanitizeMon(SCRIPTCONTEXT *ctx) {
                         SetBoxMonData(daycareMon, MON_DATA_MOVE1 + potentialOverrideMoveSlot, &newMove);
                         pp = GetBoxMonData(daycareMon, MON_DATA_MOVE1MAXPP + potentialOverrideMoveSlot, NULL);
                         SetBoxMonData(daycareMon, MON_DATA_MOVE1PP + potentialOverrideMoveSlot, &pp);
-                        break;
+                        potentialOverrideMoveSlot++;
+                        if (potentialOverrideMoveSlot >= 4) {
+                            break;
+                        }
                     }
                 }
             }

--- a/src/individual/GetMonEvolutionInternal.c
+++ b/src/individual/GetMonEvolutionInternal.c
@@ -24,7 +24,7 @@
     { \
         for (j = 0; j < party->count; j++) \
         { \
-            ppFromParty = PokeParty_GetMemberPointer(party, j); \
+            ppFromParty = Party_GetMonByIndex(party, j); \
             if (CheckIfMonsAreEqual(pokemon, ppFromParty)) \
                 break; \
         } \
@@ -310,8 +310,8 @@ u16 GetMonEvolutionInternal(struct Party *party, struct PartyPokemon *pokemon, u
                 {
                     for (int k = 0; k < 6; k++)
                     {
-                        if (!CheckIfMonsAreEqual(pokemon, PokeParty_GetMemberPointer(party, k)) // make sure that pancham doesn't satisfy its own requirement
-                         && (GetMonData(PokeParty_GetMemberPointer(party, k), MON_DATA_TYPE_1, NULL) == TYPE_DARK || GetMonData(PokeParty_GetMemberPointer(party, k), MON_DATA_TYPE_2, NULL) == TYPE_DARK)) // if either type is dark then set evolution
+                        if (!CheckIfMonsAreEqual(pokemon, Party_GetMonByIndex(party, k)) // make sure that pancham doesn't satisfy its own requirement
+                         && (GetMonData(Party_GetMonByIndex(party, k), MON_DATA_TYPE_1, NULL) == TYPE_DARK || GetMonData(Party_GetMonByIndex(party, k), MON_DATA_TYPE_2, NULL) == TYPE_DARK)) // if either type is dark then set evolution
                         {
                             GET_TARGET_AND_SET_FORM;
                             *method_ret = EVO_LEVEL_DARK_TYPE_MON_IN_PARTY;

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -687,7 +687,7 @@ u32 LONG_CALL CanUseDNASplicersGrabSplicerPos(struct PartyPokemon *pp, struct Pa
 
     for (s32 i = 0; i < ((form_no != 0) ? 6 : party->count); i++) // check all 6 party slots if looking to revert
     {
-        struct PartyPokemon *currentmon = PokeParty_GetMemberPointer(party, i);
+        struct PartyPokemon *currentmon = Party_GetMonByIndex(party, i);
         u32 species2 = GetMonData(currentmon, MON_DATA_SPECIES, NULL);
 
         if (species2 == 0 && form_no != 0) // looking for empty slot to dump reshiram to from save
@@ -764,7 +764,7 @@ u16 NatureToMintItem[] =
  */
 u32 LONG_CALL UseItemMonAttrChangeCheck(struct PLIST_WORK *wk, void *dat)
 {
-    struct PartyPokemon *pp = PokeParty_GetMemberPointer(wk->dat->pp, wk->pos);
+    struct PartyPokemon *pp = Party_GetMonByIndex(wk->dat->pp, wk->pos);
     partyMenuSignal = 0; // ensure it is 0 before potentially queuing up a different message
 
     // handle shaymin
@@ -813,7 +813,7 @@ u32 LONG_CALL UseItemMonAttrChangeCheck(struct PLIST_WORK *wk, void *dat)
             // grab reshiram from save
             // add reshiram to party--can't just use PokeParty_Add because icons freak out when you tell them to animate something that isn't there
             //PokeParty_Add(wk->dat->pp, &saveMiscData->storedMons[STORED_MONS_DNA_SPLICERS]);
-            struct PartyPokemon *reshiram = PokeParty_GetMemberPointer(wk->dat->pp, splicer_pos);
+            struct PartyPokemon *reshiram = Party_GetMonByIndex(wk->dat->pp, splicer_pos);
             *reshiram = saveMiscData->storedMons[STORED_MONS_DNA_SPLICERS];
             partyMenuSignal = 1;
 
@@ -831,7 +831,7 @@ u32 LONG_CALL UseItemMonAttrChangeCheck(struct PLIST_WORK *wk, void *dat)
         {
             // grab reshiram from party
             // store reshiram in save
-            saveMiscData->storedMons[STORED_MONS_DNA_SPLICERS] = *PokeParty_GetMemberPointer(wk->dat->pp, splicer_pos); // may have to directly memcpy this but this is good for the moment
+            saveMiscData->storedMons[STORED_MONS_DNA_SPLICERS] = *Party_GetMonByIndex(wk->dat->pp, splicer_pos); // may have to directly memcpy this but this is good for the moment
             // delete reshiram from party--splicer_pos has the position to delete
             PokeParty_Delete(wk->dat->pp, splicer_pos);
             saveMiscData->isMonStored[STORED_MONS_DNA_SPLICERS] = 1;
@@ -839,7 +839,7 @@ u32 LONG_CALL UseItemMonAttrChangeCheck(struct PLIST_WORK *wk, void *dat)
             if (splicer_pos < wk->pos) // adjust this position back so that the right pokemon's forme gets changed
             {
                 wk->pos--;
-                pp = PokeParty_GetMemberPointer(wk->dat->pp, wk->pos);
+                pp = Party_GetMonByIndex(wk->dat->pp, wk->pos);
             }
 
             if (reshiramBool) // turn to white kyurem
@@ -1049,7 +1049,7 @@ BOOL LONG_CALL Party_UpdateDeerlingSeasonForm(struct Party *party)
 
     for (int i = 0; i < party->count; i++)
     {
-        struct PartyPokemon *pp = PokeParty_GetMemberPointer(party, i);
+        struct PartyPokemon *pp = Party_GetMonByIndex(party, i);
         u32 species = GetMonData(pp, MON_DATA_SPECIES, NULL);
         u32 newForm = GrabCurrentSeason();
         if (newForm != GetMonData(pp, MON_DATA_FORM, NULL) && (species == SPECIES_DEERLING || species == SPECIES_SAWSBUCK))
@@ -1186,7 +1186,7 @@ u32 LONG_CALL CheckIfMonsAreEqual(struct PartyPokemon *pokemon1, struct PartyPok
     { \
         for (j = 0; j < party->count; j++) \
         { \
-            ppFromParty = PokeParty_GetMemberPointer(party, j); \
+            ppFromParty = Party_GetMonByIndex(party, j); \
             if (CheckIfMonsAreEqual(pokemon, ppFromParty)) \
                 break; \
         } \


### PR DESCRIPTION
- [x] Core functionality of Mirror Herb. In Gen 9, if a Pokémon holds a Mirror Herb, it will receive Egg Moves from the other regardless of species.
- [x] Deposit order does not matter.
- [x] Inherit more than 1 Egg Move.
- [x] Starting in Gen 8, if two Pokémon of the same species are together in the Pokémon Nursery, one knows an Egg Move, and the other has an empty slot, the other Pokémon will receive the Egg Move in the empty slot.
- [x] Egg Moves are transferred in the same order they appear on the move list ([Egg Move](https://bulbapedia.bulbagarden.net/wiki/Egg_Move)). ~Moves are transferred in descending order on the move list ([Pokémon Nursery](https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_Nursery#Galar)).~