### PR TITLE
Modernise Trick Room

### DIFF
--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -823,6 +823,11 @@ u8 CalcSpeed(void *bw, struct BattleStruct *sp, int client1, int client2, int fl
         }
     }
 
+    if (sp->field_condition & FIELD_STATUS_TRICK_ROOM) {
+        speed1 = (10000 - speed1) % 8192;
+        speed2 = (10000 - speed2) % 8192;
+    }
+
     if (priority1 == priority2)
     {
         if ((quick_claw1) && (quick_claw2)) // both mons quick claws activates/items that put them first
@@ -881,17 +886,6 @@ u8 CalcSpeed(void *bw, struct BattleStruct *sp, int client1, int client2, int fl
         else if ((ability1 != ABILITY_STALL) && (ability2 == ABILITY_STALL))
         {
             ret = 0;
-        }
-        else if (sp->field_condition & FIELD_STATUS_TRICK_ROOM)
-        {
-            if (speed1 > speed2)
-            {
-                ret = 1;
-            }
-            if ((speed1 == speed2) && (BattleRand(bw) & 1))
-            {
-                ret = 2;
-            }
         }
         else
         {


### PR DESCRIPTION
From [Generation V](https://bulbapedia.bulbagarden.net/wiki/Generation_V) onwards, due to the way Trick Room affects Speed calculation, Pokémon with 1809 or more Speed will still act before Pokémon slower than 1809, even in Trick Room. Specifically, Pokémon with a Speed stat closest to 1809 without going under go first. This is because, **under Trick Room, every Pokemon's Speed is set to (10,000 - (their actual Speed)) modulo 8,192**.