### PR TITLE
Implement Dynamic Speed

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -2585,4 +2585,13 @@ typedef enum Terrain {
  */
 void LoadDifferentBattleBackground(struct BattleSystem *bw, u32 bg, u32 terrain);
 
+/**
+ *  @brief Sorts clients' execution order factoring in who has already performed their action
+ *  @param bw battle work structure; void * because we haven't defined the battle work structure. Apparently we have but we don't use it here so
+ *  @param sp global battle structure
+ */
+void DynamicSortClientExecutionOrder(void *bw, struct BattleStruct *sp);
+
+void LONG_CALL BattleControllerPlayer_CalcExecutionOrder(struct BattleSystem *bw, struct BattleStruct *sp);
+
 #endif // BATTLE_H

--- a/include/battle.h
+++ b/include/battle.h
@@ -2399,6 +2399,9 @@ u32 ServerWazaKoyuuCheck(void *bw, struct BattleStruct *sp);
  */
 u8 CalcSpeed(void *bw, struct BattleStruct *sp, int client1, int client2, int flag);
 
+#define CALCSPEED_FLAG_NOTHING 0
+#define CALCSPEED_FLAG_NO_PRIORITY 0x80
+
 /**
  *  @brief set move status effects for super effective and calculate modified damage
  *

--- a/rom.ld
+++ b/rom.ld
@@ -581,3 +581,5 @@ AddWindowParameterized = 0x0201D40C | 1;
 
 LoadLevelUpLearnset_HandleAlternateForm = 0x02071FC8 | 1;
 TryAppendMonMove = 0x0207137C | 1;
+
+BattleControllerPlayer_CalcExecutionOrder = 0x02249190 | 1;

--- a/src/battle/ability.c
+++ b/src/battle/ability.c
@@ -348,6 +348,8 @@ BOOL IntimidateCheckHelper(struct BattleStruct *sp, u32 client)
  */
 int SwitchInAbilityCheck(void *bw, struct BattleStruct *sp)
 {
+    // Sort clients because abilities may affect speed
+    DynamicSortClientExecutionOrder(bw, sp);
     int i;
     int scriptnum = 0;
     int ret = SWITCH_IN_CHECK_LOOP;
@@ -2588,10 +2590,10 @@ enum
  */
 void ServerDoPostMoveEffects(void *bw, struct BattleStruct *sp)
 {
-    switch(sp->swoak_seq_no)
-    {
-    case SWOAK_SEQ_VANISH_ON_OFF:
-        {
+    // Sort clients because moves may affect speed
+    DynamicSortClientExecutionOrder(bw, sp);
+    switch (sp->swoak_seq_no) {
+        case SWOAK_SEQ_VANISH_ON_OFF: {
             int ret = 0;
             while(sp->swoak_work < BattleWorkClientSetMaxGet(bw))
             {

--- a/src/battle/battle_start.c
+++ b/src/battle/battle_start.c
@@ -69,6 +69,9 @@ void ServerBeforeAct(void *bw, struct BattleStruct *sp)
 
     do
     {
+        // Here we recalculate the execution order without considering who has already performed
+        // their action because this function takes place before anyone has performed an action
+        BattleControllerPlayer_CalcExecutionOrder(bw, sp);
         switch (sp->sba_seq_no)
         {
         case SBA_RESET_DEFIANT:

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -907,6 +907,85 @@ u8 CalcSpeed(void *bw, struct BattleStruct *sp, int client1, int client2, int fl
     return ret;
 }
 
+/**
+ *  @brief Sorts clients' execution order factoring in who has already performed their action
+ *  @param bw battle work structure; void * because we haven't defined the battle work structure. Apparently we have but we don't use it here so
+ *  @param sp global battle structure
+ */
+void DynamicSortClientExecutionOrder(void *bw, struct BattleStruct *sp) {
+    int maxBattlers;
+    int i, j;
+    int temp1, temp2;
+    int currentAttackerId = 0;
+
+    maxBattlers = BattleWorkClientSetMaxGet(bw);
+
+    for (i = 0; i < maxBattlers; i++) {
+        if (sp->attack_client == sp->client_agi_work[i]) {
+            currentAttackerId = i;
+        }
+    }
+
+    // u8 buf[64];
+    // sprintf(buf, "Current attacker: %d\n", sp->attack_client);
+    // debugsyscall(buf);
+    // sprintf(buf, " Before turn_order: ");
+    // debugsyscall(buf);
+
+    // for (i = 0; i < maxBattlers; i++) {
+    //     sprintf(buf, "%d ", sp->client_agi_work[i]);
+    //     debugsyscall(buf);
+    // }
+
+    // sprintf(buf, "\n\n");
+    // debugsyscall(buf);
+
+    for (i = currentAttackerId; i < maxBattlers - 1; i++) {
+        // sprintf(buf, "i: %d\n", i);
+        // debugsyscall(buf);
+        for (j = i + 1; j < maxBattlers; j++) {
+            // sprintf(buf, "j: %d\n", j);
+            // debugsyscall(buf);
+            temp1 = sp->client_agi_work[i];
+            temp2 = sp->client_agi_work[j];
+
+            u32 command1 = sp->client_act_work[temp1][3];
+            u32 command2 = sp->client_act_work[temp2][3];
+
+            // sprintf(buf, "temp1: %d\ntemp2: %d\n", temp1, temp2);
+            // debugsyscall(buf);
+
+            u8 flag;
+
+            if (command1 == command2) {
+                if (command1 == SELECT_FIGHT_COMMAND) {
+                    flag = 0;
+                } else {
+                    flag = 1;
+                }
+                // sprintf(buf, "Comparing client %d and %d\n", temp1, temp2);
+                // debugsyscall(buf);
+                if (CalcSpeed(bw, sp, temp1, temp2, flag)) {
+                    // sprintf(buf, "Swapping %d and %d\n", temp1, temp2);
+                    // debugsyscall(buf);
+                    sp->client_agi_work[i] = temp2;
+                    sp->client_agi_work[j] = temp1;
+                }
+            }
+        }
+    }
+
+    // sprintf(buf, " After turn_order: ");
+    // debugsyscall(buf);
+
+    // for (i = 0; i < maxBattlers; i++) {
+    //     sprintf(buf, "%d ", sp->client_agi_work[i]);
+    //     debugsyscall(buf);
+    // }
+
+    // sprintf(buf, "\n\n");
+    // debugsyscall(buf);
+}
 
 const u8 CriticalRateTable[] =
 {

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -828,6 +828,12 @@ u8 CalcSpeed(void *bw, struct BattleStruct *sp, int client1, int client2, int fl
         speed2 = (10000 - speed2) % 8192;
     }
 
+    if (flag & CALCSPEED_FLAG_NO_PRIORITY)
+    {
+        priority1 = 0;
+        priority2 = 0;
+    }
+
     if (priority1 == priority2)
     {
         if ((quick_claw1) && (quick_claw2)) // both mons quick claws activates/items that put them first
@@ -971,6 +977,18 @@ void DynamicSortClientExecutionOrder(void *bw, struct BattleStruct *sp) {
                     sp->client_agi_work[i] = temp2;
                     sp->client_agi_work[j] = temp1;
                 }
+            }
+        }
+    }
+
+    for (i = currentAttackerId; i < maxBattlers - 1; i++) {
+        for (j = i + 1; j < maxBattlers; j++) {
+            temp1 = sp->turn_order[i];
+            temp2 = sp->turn_order[j];
+
+            if (CalcSpeed(bw, sp, temp1, temp2, CALCSPEED_FLAG_NO_PRIORITY)) {
+                sp->turn_order[i] = temp2;
+                sp->turn_order[j] = temp1;
             }
         }
     }


### PR DESCRIPTION
In [Generation VII](https://bulbapedia.bulbagarden.net/wiki/Generation_VII), A Pokémon's Speed after [Mega Evolution](https://bulbapedia.bulbagarden.net/wiki/Mega_Evolution) is used to determine the turn order, not its Speed before ([Alterations from Generation VI](https://bulbapedia.bulbagarden.net/wiki/Generation_VII#Alterations_from_Generation_VI)).

In Generation 8, Speed is recalculated mid-turn before each individual Pokémon moves ([Pokémon Sword and Shield – New Competitive Features and Mechanic Changes](https://www.trainertower.com/pokemon-sword-and-shield-new-competitive-features-and-mechanic-changes/)).