### PR TITLE
make competitive/defiant to actually raise stats on any stat lowered

### DIFF
--- a/src/individual/MoveHitDefenderAbilityCheck.c
+++ b/src/individual/MoveHitDefenderAbilityCheck.c
@@ -403,7 +403,7 @@ BOOL MoveHitDefenderAbilityCheckInternal(void *bw, struct BattleStruct *sp, int 
                 sp->state_client = sp->defence_client;
                 sp->client_work = sp->defence_client;
                 sp->addeffect_type = ADD_EFFECT_ABILITY;
-                seq_no[0] = SUB_SEQ_HANDLE_DEFIANT;
+                seq_no[0] = SUB_SEQ_BOOST_STATS; //SUB_SEQ_HANDLE_DEFIANT;
                 ret = TRUE;
             }
             break;
@@ -424,7 +424,7 @@ BOOL MoveHitDefenderAbilityCheckInternal(void *bw, struct BattleStruct *sp, int 
                 sp->state_client = sp->defence_client;
                 sp->client_work = sp->defence_client;
                 sp->addeffect_type = ADD_EFFECT_ABILITY;
-                seq_no[0] = SUB_SEQ_HANDLE_COMPETITIVE;
+                seq_no[0] = SUB_SEQ_BOOST_STATS; //SUB_SEQ_HANDLE_COMPETITIVE;
                 ret = TRUE;
             }
             break;

--- a/src/individual/MoveHitDefenderAbilityCheck.c
+++ b/src/individual/MoveHitDefenderAbilityCheck.c
@@ -395,6 +395,10 @@ BOOL MoveHitDefenderAbilityCheckInternal(void *bw, struct BattleStruct *sp, int 
              && ((sp->server_status_flag & SERVER_STATUS_FLAG_x20) == 0)
              && ((sp->server_status_flag2 & SERVER_STATUS_FLAG2_U_TURN) == 0))
             {
+                if (sp->battlemon[sp->defence_client].states[STAT_ATTACK] < 11)
+                    sp->addeffect_param = ADD_STATE_ATTACK_UP_2;
+                else
+                    sp->addeffect_param = ADD_STATE_ATTACK_UP;
                 sp->oneSelfFlag[sp->state_client].defiant_flag = 0;
                 sp->state_client = sp->defence_client;
                 sp->client_work = sp->defence_client;
@@ -412,6 +416,10 @@ BOOL MoveHitDefenderAbilityCheckInternal(void *bw, struct BattleStruct *sp, int 
              && ((sp->server_status_flag & SERVER_STATUS_FLAG_x20) == 0)
              && ((sp->server_status_flag2 & SERVER_STATUS_FLAG2_U_TURN) == 0))
             {
+                if (sp->battlemon[sp->defence_client].states[STAT_SPATK] < 11)
+                    sp->addeffect_param = ADD_STATE_SP_ATK_UP_2;
+                else
+                    sp->addeffect_param = ADD_STATE_SP_ATK_UP;
                 sp->oneSelfFlag[sp->state_client].defiant_flag = 0;
                 sp->state_client = sp->defence_client;
                 sp->client_work = sp->defence_client;


### PR DESCRIPTION
Message was already printed. The actual stat changes were not done.

- [x] test previous use of battle_sub_seq 335/309 for competitive/defiant to actually raise stats. Message was printed anyway.
- [ ] add interaction with Intimidate

potentially is part of a fix for #130 