### PR TITLE
add support for trade item evolutions with the linking cord

### DIFF
--- a/src/individual/GetMonEvolutionInternal.c
+++ b/src/individual/GetMonEvolutionInternal.c
@@ -426,6 +426,11 @@ u16 GetMonEvolutionInternal(struct Party *party, struct PartyPokemon *pokemon, u
                 *method_ret = 0;
                 break;
             }
+            if (evoTable[i].method == EVO_TRADE_ITEM && heldItem == evoTable[i].param && usedItem == ITEM_LINKING_CORD) {
+                GET_TARGET_AND_SET_FORM;
+                *method_ret = 0;
+                break;
+            }
         }
         break;
     }


### PR DESCRIPTION
Allow the linking cord to be used to evolve Pokemon that require an item to be held while traded, as long as that item is being held