### PR TITLE
Fixes #302 by commenting out some lines

### DIFF
--- a/data/battle_scripts/subscripts/subscript_0003_ESCAPE.s
+++ b/data/battle_scripts/subscripts/subscript_0003_ESCAPE.s
@@ -3,12 +3,14 @@
 .data
 
 _000:
-    TryRestoreStatusOnSwitch BATTLER_CATEGORY_PLAYER_SLOT_1, _007
-    UpdateMonData OPCODE_SET, BATTLER_CATEGORY_PLAYER_SLOT_1, BMON_DATA_STATUS, STATUS_NONE
+    // Modernise Gen 8+: Natural Cure no longer heals status conditions upon completing a battle.
+    // TryRestoreStatusOnSwitch BATTLER_CATEGORY_PLAYER_SLOT_1, _007
+    // UpdateMonData OPCODE_SET, BATTLER_CATEGORY_PLAYER_SLOT_1, BMON_DATA_STATUS, STATUS_NONE
 
 _007:
-    TryRestoreStatusOnSwitch BATTLER_CATEGORY_PLAYER_SLOT_2, _015
-    UpdateMonData OPCODE_SET, BATTLER_CATEGORY_PLAYER_SLOT_2, BMON_DATA_STATUS, STATUS_NONE
+    // Also bugfix: Avoids double Regenerator activation
+    // TryRestoreStatusOnSwitch BATTLER_CATEGORY_PLAYER_SLOT_2, _015
+    // UpdateMonData OPCODE_SET, BATTLER_CATEGORY_PLAYER_SLOT_2, BMON_DATA_STATUS, STATUS_NONE
 
 _015:
     PlaySound BATTLER_CATEGORY_ATTACKER, 1791

--- a/data/battle_scripts/subscripts/subscript_0004_BATTLE_WON.s
+++ b/data/battle_scripts/subscripts/subscript_0004_BATTLE_WON.s
@@ -3,12 +3,14 @@
 .data
 
 _000:
-    TryRestoreStatusOnSwitch BATTLER_CATEGORY_PLAYER_SLOT_1, _007
-    UpdateMonData OPCODE_SET, BATTLER_CATEGORY_PLAYER_SLOT_1, BMON_DATA_STATUS, STATUS_NONE
+    // Modernise to Gen 8+: Natural Cure no longer heals status conditions upon completing a battle.
+    // TryRestoreStatusOnSwitch BATTLER_CATEGORY_PLAYER_SLOT_1, _007
+    // UpdateMonData OPCODE_SET, BATTLER_CATEGORY_PLAYER_SLOT_1, BMON_DATA_STATUS, STATUS_NONE
 
 _007:
-    TryRestoreStatusOnSwitch BATTLER_CATEGORY_PLAYER_SLOT_2, _015
-    UpdateMonData OPCODE_SET, BATTLER_CATEGORY_PLAYER_SLOT_2, BMON_DATA_STATUS, STATUS_NONE
+    // Also bugfix: Avoids double Regeneration activation
+    // TryRestoreStatusOnSwitch BATTLER_CATEGORY_PLAYER_SLOT_2, _015
+    // UpdateMonData OPCODE_SET, BATTLER_CATEGORY_PLAYER_SLOT_2, BMON_DATA_STATUS, STATUS_NONE
 
 _015:
     CompareVarToValue OPCODE_FLAG_NOT, BSCRIPT_VAR_BATTLE_TYPE, BATTLE_TYPE_TRAINER, _147


### PR DESCRIPTION
Commented out TryRestoreStatusOnSwitch commands in Escape and Battle Won subscripts as Natural Cure no longer cures status conditions after completing a battle (as of Generation 8). This also fixes the double regenerator quirk in single battles.
![melonDS_20240817-130449249](https://github.com/user-attachments/assets/8a4ea712-e263-4b3f-b92f-ad69bb9b1283)
