### PR TITLE
Reorder hazards and Mirror Armor/Sticky Web interaction

### DIFF
--- a/data/battle_scripts/subscripts/subscript_0099_HAZARDS_CHECK.s
+++ b/data/battle_scripts/subscripts/subscript_0099_HAZARDS_CHECK.s
@@ -77,6 +77,8 @@ _checkStickyWeb:
     PrintMessage 1486, TAG_NICKNAME, BATTLER_CATEGORY_SWITCHED_MON
     Wait
     WaitButtonABTime 30
+    // As of Gen 9: If Mirror Armor mon switches in, skip stat drop after displaying caught in webs message
+    CheckAbility CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, ABILITY_MIRROR_ARMOR, _checkStealthRock
     UpdateVarFromVar OPCODE_SET, BSCRIPT_VAR_BATTLER_STAT_CHANGE, BSCRIPT_VAR_BATTLER_SWITCH
     UpdateVar OPCODE_SET, BSCRIPT_VAR_SIDE_EFFECT_PARAM, MOVE_SUBSCRIPT_PTR_SPEED_DOWN_1_STAGE
     Call BATTLE_SUBSCRIPT_UPDATE_STAT_STAGE

--- a/data/battle_scripts/subscripts/subscript_0099_HAZARDS_CHECK.s
+++ b/data/battle_scripts/subscripts/subscript_0099_HAZARDS_CHECK.s
@@ -25,41 +25,18 @@ _printUnnerveMessage:
 _realHazardsCheck:
     // toxic spikes can inflict poison through magic guard, but not subsequently damage the mon (which is already handled in the damage subscript)
     //CheckAbility CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, ABILITY_MAGIC_GUARD, _105
-    CompareVarToValue OPCODE_FLAG_SET, BSCRIPT_VAR_FIELD_CONDITION, FIELD_CONDITION_GRAVITY, _checkToxicSpikes
-    CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_SPEED_DOWN_GROUNDED, _checkToxicSpikes
+    CompareVarToValue OPCODE_FLAG_SET, BSCRIPT_VAR_FIELD_CONDITION, FIELD_CONDITION_GRAVITY, _checkSpikes
+    CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_SPEED_DOWN_GROUNDED, _checkSpikes
     CheckAbility CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, ABILITY_LEVITATE, _checkStealthRock
     CompareMonDataToValue OPCODE_EQU, BATTLER_CATEGORY_SWITCHED_MON, BMON_DATA_TYPE_1, TYPE_FLYING, _checkStealthRock
     CompareMonDataToValue OPCODE_EQU, BATTLER_CATEGORY_SWITCHED_MON, BMON_DATA_TYPE_2, TYPE_FLYING, _checkStealthRock
     CompareMonDataToValue OPCODE_FLAG_SET, BATTLER_CATEGORY_SWITCHED_MON, BMON_DATA_MOVE_EFFECT, MOVE_EFFECT_FLAG_MAGNET_RISE, _checkStealthRock
     CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_UNGROUND_DESTROYED_ON_HIT, _checkStealthRock
 
-_checkToxicSpikes:
-    CheckToxicSpikes BATTLER_CATEGORY_SWITCHED_MON, _checkSpikes
-    CompareVarToValue OPCODE_EQU, BSCRIPT_VAR_CALC_TEMP, 0x00000002, _badlyPoison
-    CompareVarToValue OPCODE_EQU, BSCRIPT_VAR_CALC_TEMP, 0x00000001, _regularPoison
-    // The poison spikes disappeared from around your team’s feet!
-    PrintMessage 1065, TAG_NONE_SIDE, BATTLER_CATEGORY_SWITCHED_MON
-    Wait 
-    WaitButtonABTime 30
-    GoTo _checkSpikes
-
-_regularPoison:
-    // a mon with comatose can not be poisoned by toxic spikes
-    CheckAbility CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, ABILITY_COMATOSE, _checkSpikes
-    CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_IGNORE_ENTRY_HAZARDS, _end
-    Call BATTLE_SUBSCRIPT_POISON
-    GoTo _checkSpikes
-
-_badlyPoison:
-    // a mon with comatose can not be poisoned by toxic spikes
-    CheckAbility CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, ABILITY_COMATOSE, _checkSpikes
-    CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_IGNORE_ENTRY_HAZARDS, _end
-    Call BATTLE_SUBSCRIPT_BADLY_POISON
-
 _checkSpikes:
-    // ignore any further entry hazards with heavy duty boots
-    CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_IGNORE_ENTRY_HAZARDS, _end
-    CheckSpikes BATTLER_CATEGORY_SWITCHED_MON, _checkStickyWeb
+    // Skip spikes damage if HDB, but still check TSpikes for grounded Poison types to clear it.
+    CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_IGNORE_ENTRY_HAZARDS, _checkToxicSpikes
+    CheckSpikes BATTLER_CATEGORY_SWITCHED_MON, _checkToxicSpikes
     UpdateVarFromVar OPCODE_SET, BSCRIPT_VAR_MSG_BATTLER_TEMP, BSCRIPT_VAR_BATTLER_SWITCH
     UpdateVar OPCODE_FLAG_ON, BSCRIPT_VAR_BATTLE_STATUS, BATTLE_STATUS_NO_BLINK
     Call BATTLE_SUBSCRIPT_UPDATE_HP
@@ -67,6 +44,31 @@ _checkSpikes:
     PrintMessage 429, TAG_NICKNAME, BATTLER_CATEGORY_SWITCHED_MON
     Wait 
     WaitButtonABTime 30
+
+_checkToxicSpikes:
+    CheckToxicSpikes BATTLER_CATEGORY_SWITCHED_MON, _checkStickyWeb
+    CompareVarToValue OPCODE_EQU, BSCRIPT_VAR_CALC_TEMP, 0x00000002, _badlyPoison
+    CompareVarToValue OPCODE_EQU, BSCRIPT_VAR_CALC_TEMP, 0x00000001, _regularPoison
+    // The poison spikes disappeared from around your team’s feet!
+    PrintMessage 1065, TAG_NONE_SIDE, BATTLER_CATEGORY_SWITCHED_MON
+    Wait 
+    WaitButtonABTime 30
+    GoTo _checkStickyWeb
+
+_regularPoison:
+    // a mon with comatose can not be poisoned by toxic spikes
+    CheckAbility CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, ABILITY_COMATOSE, _checkStickyWeb
+    CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_IGNORE_ENTRY_HAZARDS, _end
+    Call BATTLE_SUBSCRIPT_POISON
+    GoTo _checkStickyWeb
+
+_badlyPoison:
+    // a mon with comatose can not be poisoned by toxic spikes
+    CheckAbility CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, ABILITY_COMATOSE, _checkStickyWeb
+    CheckItemHoldEffect CHECK_OPCODE_HAVE, BATTLER_CATEGORY_SWITCHED_MON, HOLD_EFFECT_IGNORE_ENTRY_HAZARDS, _end
+    Call BATTLE_SUBSCRIPT_BADLY_POISON
+
+// TODO: G-Max Steelsurge Hazard should be here for the correct order
 
 _checkStickyWeb:
     UpdateVarFromVar OPCODE_SET, BSCRIPT_VAR_BATTLER_ATTACKER, BSCRIPT_VAR_BATTLER_SWITCH


### PR DESCRIPTION
* Reorders Spikes over Toxic Spikes. Fixes #341 
![melonDS_20241027-193802627](https://github.com/user-attachments/assets/7d26c69a-3bd7-4dc7-9d1a-9e7cb6d7828e)

* Cancels the speed drop from Sticky Web if mon has Mirror Armor (The rest of Mirror Armor is not implemented yet). As of Gen 9, it doesn't care about who set it at all.
![melonDS_20241027-194543650](https://github.com/user-attachments/assets/49c1ed2c-ed17-4dfe-941d-69b47f415cd5)