### PR TITLE
Added Pixilate to Sylveon

### DIFF
--- a/armips/data/mondata.s
+++ b/armips/data/mondata.s
@@ -15776,7 +15776,7 @@ mondata SPECIES_SYLVEON, "Sylveon"
     basefriendship 50
     growthrate GROWTH_MEDIUM_FAST
     egggroups EGG_GROUP_FIELD, EGG_GROUP_FIELD
-    abilities ABILITY_CUTE_CHARM, ABILITY_NONE
+    abilities ABILITY_CUTE_CHARM, ABILITY_PIXILATE
     runchance 0
     colorflip BODY_COLOR_PINK, 0
     mondexentry SPECIES_SYLVEON, "It sends a soothing aura from its\nribbonlike feelers to calm fights."


### PR DESCRIPTION
I noticed Pixilate was missing from Sylveon so I added it. 
Love the project, working on a (vibe-coded) randomizer tool for HG Engine optimized for Nuzlockes—which wouldn't be possible without HG-Engine. Keep up the good work.