### PR TITLE
Fix Flower Veil & Protean (+Extras)

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -1614,8 +1614,12 @@ enum
     BATTLE_MON_DATA_SLOW_START_COUNTER = 89,
 };
 
-#define BATTLE_MON_HAS_TYPE(sp, client, type) (sp->battlemon[client].type1 == type || sp->battlemon[client].type2 == type)
-
+#define BATTLE_MON_HAS_TYPE(sp, client, type) (
+    (!(sp->battlemon[client].is_currently_terastallized) // Only check the client's base types if they are not terastallized. 
+         && (sp->battlemon[client].type1 == type
+         || sp->battlemon[client].type2 == type
+         || sp->battlemon[client].type3 == type))
+         || (sp->battlemon[client].is_currently_terastallized && sp->battlemon[client].tera_type == type));
 #define MEGA_NEED 1
 #define MEGA_CHECK_APPER 2
 #define MEGA_NO_NEED 0

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -3134,10 +3134,11 @@ int LONG_CALL GetClientActionPriority(struct BattleSystem *bsys UNUSED, struct B
 BOOL LONG_CALL HasType(struct BattleStruct *ctx, int battlerId, int type) {
     GF_ASSERT(TYPE_NORMAL < type && type < TYPE_STELLAR);
     struct BattlePokemon *client = &ctx->battlemon[battlerId];
-    return (client->type1 == type
+    return ((!(client->is_currently_terastallized) // Only check the client's base types if they are not terastallized. 
+         && (client->type1 == type
          || client->type2 == type
-         || client->type3 == type
-         || (client->is_currently_terastallized ? client->tera_type == type : FALSE));
+         || client->type3 == type))
+         || (client->is_currently_terastallized && client->tera_type == type));
 }
 
 

--- a/src/individual/CalculateBallShakes.c
+++ b/src/individual/CalculateBallShakes.c
@@ -50,7 +50,7 @@ u16 MoonBallSpecies[] =
  *  @return the amount of shakes a ball undergoes.  or'd with CRITICAL_CAPTURE_MASK for critical captures
  */
 u32 __attribute__((section (".init"))) CalculateBallShakesInternal(void *bw, struct BattleStruct *sp) {
-    u32 i, speciesCatchRate, ballCaptureRatio, type1, type2, criticalCapture = FALSE;
+    u32 i, speciesCatchRate, ballCaptureRatio, criticalCapture = FALSE;
     u32 heavyBallMod = 0, modifiedCatchRate = 0;
     u64 a = 0, b = 0, c = 0, d = 0, e = 0, f = 0, g = 0, captureValueCoeffcient = 0, badgePenalty = UQ412__1_0, statusModifier = 0, criticalCatchModifier = 0, speciesInDex = 0, criticalCatchRate = 0, shakeChecks = 4, shakeChance = 0;
     int badges, missingBadges;
@@ -72,9 +72,6 @@ u32 __attribute__((section (".init"))) CalculateBallShakesInternal(void *bw, str
     }
 
     ballCaptureRatio = 0x1000;
-    type1 = BattlePokemonParamGet(sp, sp->defence_client, BATTLE_MON_DATA_TYPE1, 0); // type 1
-    type2 = BattlePokemonParamGet(sp, sp->defence_client, BATTLE_MON_DATA_TYPE2, 0); // type 2
-
 
     switch (sp->item_work)
     {
@@ -96,7 +93,7 @@ u32 __attribute__((section (".init"))) CalculateBallShakesInternal(void *bw, str
         ballCaptureRatio = 0x1000;
         break;
     case ITEM_NET_BALL:
-        if (type1 == TYPE_WATER || type2 == TYPE_WATER || type1 == TYPE_BUG || type2 == TYPE_BUG) {
+        if (HasType(sp, sp->defence_client, TYPE_WATER) || HasType(sp, sp->defence_client, TYPE_BUG)) {
             ballCaptureRatio = 0x3800;
         }
         break;

--- a/src/individual/btl_scr_cmd_33_statbuffchange.c
+++ b/src/individual/btl_scr_cmd_33_statbuffchange.c
@@ -251,9 +251,10 @@ BOOL btl_scr_cmd_33_statbuffchange(void *bw, struct BattleStruct *sp)
                 }
                 else if ((MoldBreakerAbilityCheck(sp, sp->attack_client, sp->state_client, ABILITY_FLOWER_VEIL) == TRUE
                        || MoldBreakerAbilityCheck(sp, sp->attack_client, BATTLER_ALLY(sp->state_client), ABILITY_FLOWER_VEIL) == TRUE) // any enemy has flower veil (accounting for mold breaker, otherwise would just CheckSideAbility)
-                      && (sp->battlemon[sp->state_client].type1 == TYPE_GRASS || sp->battlemon[sp->state_client].type2 == TYPE_GRASS)) // and target has grass type
+                       && HasType(sp, sp->state_client, TYPE_GRASS)) // and target has grass type
                 {
-                    // specifically for flower veil, we know that one of the Pokémon have flower veil.  we need to change the client that it prints the ability of to the flower veil client
+                    // The Pokémon with Flower Veil as an ability may not be the target of the move that triggers it. 
+                    // We need to make sure it prints the correct name and ability regardless by keeping track of the client with Flower Veil. 
                     u32 flower_veil_client;
 
                     flower_veil_client = (GetBattlerAbility(sp, sp->state_client) == ABILITY_FLOWER_VEIL) ? sp->state_client : BATTLER_ALLY(sp->state_client);


### PR DESCRIPTION
BattleController_BeforeMove.c now actually checks for the target or allies to have the Grass type. btl_scr_cmd_33_statbuffchange now also utilizes HasType(), which notably accounts for type3 and active Tera type. This change was also applied to the catch formula for Net Balls, future-proofing wild pokemon Terastallization while keeping the door open for custom type3 setter moves.

Alters HasType() in other_battle_calculators.c to correctly ignore base types if the client is Terastallized for the sake of certain moves & abilities such as Prankster.

Protean and Libero now correctly have no effect if the user uses a typeless move or is Terastallized, and more importantly actually function if the move that would trigger them has no base power.