### PR TITLE
more mac-compatible battle gfx rm command

### DIFF
--- a/narcs.mk
+++ b/narcs.mk
@@ -489,7 +489,9 @@ BATTLEGFX_DEPENDENCIES := $(wildcard $(BATTLEGFX_DEPENDENCIES_DIR)/*) $(wildcard
 
 $(BATTLEGFX_NARC): $(BATTLEGFX_DEPENDENCIES)
 	$(NARCHIVE) extract $(BATTLEGFX_TARGET) -o $(BATTLEGFX_DIR) -nf
-	for n in $$(seq 346 $$(expr $$(ls $(BATTLEGFX_DIR) | wc -l) - 1)); do rm -f $(BATTLEGFX_DIR)/8_$$n; done
+	find $(BATTLEGFX_DIR) -maxdepth 1 -type f -name '8_*' \
+	| awk -F'[/_-]' '{n=$$NF; sub(/[^0-9].*/,"",n); if (n >= 346) print $$0}' \
+	| xargs -r rm -f
 	cp -r $(BATTLEGFX_DEPENDENCIES_DIR)/. $(BATTLEGFX_DIR)
 	for file in $(BATTLEWEATHERGFX_DEPENDENCIES_DIR)/*.png; do $(GFX) $$file $(BATTLEGFX_DIR)/$$(basename $$file .png)-00.NCGR; $(GFX) $$file $(BATTLEGFX_DIR)/$$(basename $$file .png)-01.NCLR -bitdepth 8 -nopad -comp 10; done
 	for file in $(BATTLEWEATHERGFX_DEPENDENCIES_DIR)/*_terrain.png; do $(GFX) $(BATTLEGFX_DIR)/$$(basename $$file .png)-00.NCGR $(BATTLEGFX_DIR)/$$(basename $$file .png)-00.NCGR.lz; rm $(BATTLEGFX_DIR)/$$(basename $$file .png)-00.NCGR; done


### PR DESCRIPTION
I ran more comparisons on the nclr and ncgr files and couldn't find any differences between Mac and WSL byte-for-byte. Then thought maybe mac hidden file shenanigans were adding files and throwing indexes off. Finally noticed that the battlegfx narc was actually missing one file on Mac - `8_345`. 

The current command _should_ not have removed `8_345` but for whatever reason it consistently was on mac

addresses https://github.com/BluRosie/hg-engine/issues/413
also hopefully https://github.com/BluRosie/hg-engine/issues/432