### PR TITLE
add sand spit to MoveHitDefenderAbilityCheck

### DIFF
--- a/src/battle/battle_script_commands.c
+++ b/src/battle/battle_script_commands.c
@@ -4064,7 +4064,7 @@ BOOL BtlCmd_TryPluck(void* bw, struct BattleStruct* sp)
     {
         sp->mp.msg_id = BATTLE_MSG_STOLE_BERRY;
         sp->mp.msg_tag = TAG_NICKNAME_ITEM;
-        sp->mp.msg_para[0] = CreateNicknameTag(sp, sp->defence_client);
+        sp->mp.msg_para[0] = CreateNicknameTag(sp, sp->attack_client);
         sp->mp.msg_para[1] = item;
         sp->battlemon[sp->defence_client].item = 0; //no recycle
     }

--- a/src/individual/MoveHitDefenderAbilityCheck.c
+++ b/src/individual/MoveHitDefenderAbilityCheck.c
@@ -615,6 +615,20 @@ BOOL MoveHitDefenderAbilityCheckInternal(void *bw, struct BattleStruct *sp, int 
                 ret = TRUE;
             }
             break;
+        case ABILITY_SAND_SPIT:
+            if (((sp->waza_status_flag & WAZA_STATUS_FLAG_NO_OUT) == 0)
+                && ((sp->server_status_flag & SERVER_STATUS_FLAG_x20) == 0)
+                && ((sp->server_status_flag2 & SERVER_STATUS_FLAG2_U_TURN) == 0)
+                && ((sp->oneSelfFlag[sp->defence_client].physical_damage) ||
+                    (sp->oneSelfFlag[sp->defence_client].special_damage)))
+            {
+                sp->addeffect_type = ADD_EFFECT_ABILITY;
+                sp->state_client = sp->defence_client;
+                sp->battlerIdTemp = sp->defence_client;
+                seq_no[0] = SUB_SEQ_SAND_STREAM;
+                ret = TRUE;
+            }
+            break;
         default:
             break;
     }


### PR DESCRIPTION
<img width="1098" height="408" alt="image" src="https://github.com/user-attachments/assets/d97810da-5fb1-45db-be9e-c1431f9f1ed4" />
Picture order is right, then left...
Would be cooler with the ability pop-up