### PR TITLE
fix tmhm desc

### DIFF
--- a/data/text/830.txt
+++ b/data/text/830.txt
@@ -326,106 +326,106 @@ A transparent device overflowing\nwith dubious data. It’s loved by a\ncertain 
 A cloth imbued with horrifyingly\nstrong spiritual energy. It’s loved\nby a certain Pokémon.
 An item to be held by a Pokémon.\nThis sharply hooked claw boosts the\ncritical-hit ratio of the holder’s\rmoves.
 An item to be held by a Pokémon.\nThis sharply hooked fang may cause\nthe target to flinch whenever the\rholder successfully inflicts damage\non them with an attack.
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-N/A
-- - -
-- - -
-- - -
-- - -
-- - -
-- - -
-- - -
-- - -
+The user focuses its mind before\nlaunching this attack. It will fail if\nthe user is hit before it is used.
+Sharp, huge claws hook and slash\nthe foe quickly and with great\npower.
+The foe is hit with a pulsing blast\nof water. It may also confuse the\ntarget.
+The user quietly focuses its mind and\ncalms its spirit to raise its Sp. Atk\nand Sp. Def stats.
+The foe is scared off, to be replaced\nby another Pokémon in its party.\nIn the wild, the battle ends.
+A move that leaves the foe badly\npoisoned. This poison damage\nworsens every turn.
+Summons a hailstorm that lasts for\nfive turns. The hailstorm damages\nall types except Ice.
+The user tenses its muscles to bulk up\nits body, boosting both its Attack and\nDefense stats.
+The user forcefully shoots seeds at\nthe foe. Two to five seeds are shot in\nrapid succession.
+A variable move that changes type\nand power depending on the hidden\nability of the Pokémon using it.
+The user intensifies the sun for\nfive turns, powering up Fire-type\nmoves.
+The foe is taunted into a rage that\nallows it to use only attack moves for\ntwo to four turns.
+The foe is struck with an icy-cold\nbeam of energy. It may also freeze\nthe target solid.
+A howling blizzard is summoned to\nstrike the foe. It may also freeze\nthe target solid.
+The foe is attacked with a powerful\nbeam. The user must rest on the next\nturn to regain its energy.
+A wondrous wall of light is put up to\nsuppress damage from special attacks\nfor five turns.
+It enables the user to evade all\nattacks. Its chance of failing rises\nif it is used in succession.
+The user summons a heavy rain that\nfalls for five turns, powering up\nWater-type moves.
+A nutrient-draining attack. The user’s\nHP is restored by half the damage\ntaken by the target.
+The user creates a protective field\nthat prevents status problems like\npoison, paralysis, burn, and sleep.
+A full-power attack that grows more\npowerful the less the user likes its\nTrainer.
+A two-turn attack. The user gathers\nlight, then blasts a bundled beam on\nthe second turn.
+The foe is slammed with a sturdy\ntail of steel. It may also lower the\ntarget’s Defense stat if it hits.
+A strong electric blast is loosed at\nthe foe. It may also leave the foe\nparalyzed.
+A wicked thunderbolt is dropped on the\nfoe to inflict damage. It may also\nleave the target paralyzed.
+The user sets off an earthquake\nthat hits all the Pokémon in the\nbattle.
+A full-power attack that grows more\npowerful the more the user likes its\nTrainer.
+The user burrows, then attacks on the\nsecond turn. It can also be used to\nexit dungeons.
+The foe is hit by a strong telekinetic\nforce. It may also reduce the foe’s\nSp. Def stat.
+The user hurls a shadowy blob at the\nfoe. It may also lower the foe’s\nSp. Def stat.
+The user attacks with tough fists,\netc. It can also break any barrier\nsuch as Light Screen and Reflect.
+The user begins moving so quickly\nthat it creates illusory copies to\nraise its evasiveness.
+A wondrous wall of light is put up to\nsuppress damage from physical attacks\nfor five turns.
+The user strikes the foe with a quick\njolt of electricity. This attack cannot\nbe evaded.
+The foe is scorched with an intense\nblast of fire. The target may also be\nleft with a burn.
+Unsanitary sludge is hurled at\nthe foe. It may also poison the\ntarget.
+A five-turn sandstorm is summoned\nto hurt all combatants except the\nRock, Ground, and Steel types.
+The foe is attacked with an intense\nblast of all-consuming fire. It may\nalso leave the target with a burn.
+Large boulders are hurled at the foe\nto inflict damage. It lowers the foe’s\nSpeed.
+The user confounds the foe with speed,\nthen strikes. The attack lands without\nfail.
+The user torments and enrages the\nfoe, making it incapable of using the\nsame move twice in a row.
+An attack move that doubles its power\nif the user is poisoned, paralyzed, or\nhas a burn.
+An attack move with effects that\nvary depending on the user’s\nenvironment.
+The user goes to sleep for two\nturns. It fully restores the user’s HP\nand heals any status problem.
+If it is the opposite gender of the\nuser, the foe becomes infatuated\nand less likely to attack.
+The user attacks and steals the foe’s\nheld item simultaneously. It can’t\nsteal if the user holds an item.
+The foe is hit with wings of steel.\nIt may also raise the user’s Defense\nstat.
+The user employs its psychic power to\nexchange abilities with the foe.\n
+The user steals the effects of any\nhealing or status-changing move the\nfoe attempts to use.
+The user attacks the foe at full\npower using fiery energy. It also\nsharply reduces the user’s Sp. Atk.
+The user lands and rests its body.\nIt restores the user’s HP by up to\nhalf of its max HP.
+The user attacks at full power.\nIt may also lower the foe’s Sp. Def\nstat if it hits.
+The user draws power from nature and\nfires it at the foe. It may also lower\nthe target’s Sp. Def.
+A restrained attack that prevents the\nfoe from fainting. The target is left\nwith at least 1 HP.
+If the foe’s HP is down to under half,\nthis attack will hit with double the\npower.
+The user flings its held item at the\nfoe to attack. Its power and effects\ndepend on the item.
+The user attacks with an electric\ncharge. The user may use any remaining\nelectricity to raise its Sp. Atk stat.
+The user endures any attack, leaving\n1 HP. Its chance of failing rises if it\nis used in succession.
+The foe is attacked with a shock\nwave generated by the user’s gaping\nmouth.
+An energy-draining punch. The user’s\nHP is restored by half the damage\ntaken by the target.
+The user shoots a sinister, bluish\nwhite flame at the foe to inflict a\nburn.
+The foe is attacked with powdery\nscales blown by wind. It may also\nraise all the user’s stats.
+It prevents the foe from using its\nheld item. Its Trainer is also\nprevented from using items on it.
+The user explodes to inflict damage on\nall Pokémon in battle. The user faints\nupon using this move.
+The user slashes with a sharp claw\nmade from shadows. It has a high\ncritical-hit ratio.
+The user stores power, then attacks.\nIf the user can use this attack after\nthe foe, its power is doubled.
+The user recycles a single-use item\nthat has been used in battle so it can\nbe used again.
+The user charges the foe using every\nbit of its power. It must rest on the\nnext turn to recover.
+The user polishes its body to reduce\ndrag. It sharply raises the Speed\nstat.
+The user flashes a light that cuts the\nfoe’s accuracy. It can also be used to\nilluminate caves.
+The user stabs the foe with a\nsharpened stone from below. It has\na high critical-hit ratio.
+An attack move that inflicts double\nthe damage if the user has been hurt\nby the foe in the same turn.
+A weak electric charge is launched\nat the foe. It causes paralysis if it\nhits.
+The user tackles the foe from a\nhigh-speed spin. The slower the user,\nthe greater the damage.
+A frenetic dance to uplift the fighting\nspirit. It sharply raises the user’s\nAttack stat.
+The user lays a trap of levitating\nstones around the foe. The trap hurts\nfoes that switch into battle.
+The user hypnotizes itself into\ncopying any stat change made\nby the foe.
+If it is the opposite gender of the\nuser, the foe is charmed into sharply\nlowering its Sp. Atk stat.
+The user releases a horrible aura\nimbued with dark thoughts. It may also\nmake the target flinch.
+Large boulders are hurled at the foe\nto inflict damage. It may also make the\ntarget flinch.
+The user slashes at the foe by\ncrossing its scythes or claws as if\nthey were a pair of scissors.
+While it is asleep, the user\nrandomly uses one of the moves\nit knows.
+The user draws power from the Berry\nit is holding to attack. The Berry\ndetermines its type and power.
+The foe is stabbed with a tentacle or\narm steeped with poison. It may also\npoison the foe.
+An attack that works only on a\nsleeping foe. It absorbs half the\ndamage caused to heal the user’s HP.
+The user snares the foe with grass\nand trips it. The heavier the foe, the\ngreater the damage.
+The user enrages the foe into\nconfusion. However, it also sharply\nraises the foe’s Attack stat.
+The user pecks the foe. If the foe is\nholding a Berry, the user plucks it and\ngains its effect.
+After making its attack, the user\nrushes back to switch places with a\nparty Pokémon in waiting.
+The user makes a copy of itself using\nsome of its HP. The copy serves as\nthe user’s decoy.
+The user gathers all its light energy\nand releases it in one shot. It may\nalso lower the foe’s Sp. Def stat.
+The user creates a bizarre space in\nwhich slower Pokémon get to move\nfirst for five turns.
+The foe is cut with a scythe or a claw.\nIt can also be used to cut down thin\ntrees.
+The user soars, then strikes on the\nsecond turn. It can also be used to\nfly to any familiar town.
+It swamps the entire battlefield with\na giant wave. It can also be used\nto cross water.
+The foe is slugged with a punch thrown\nat maximum power. It can also be used\nto move boulders.
+Traps foes in a violent swirling\nwhirlpool. It can also be used to\ntraverse whirlpools.
+The user slugs the foe with a\nshattering punch. It can also smash\ncracked boulders.
+The user charges the foe at an\nawesome speed. It can also be used\nto climb a waterfall.
+A charging attack that may also leave\nthe foe confused. It can also be used\nto scale rocky walls.
 A bag filled with convenient tools\nfor exploring. It provides access to\nthe Underground in the Sinnoh\rregion.
 A sturdy, spacious bag that is used\nto carry any treasures or loot\nobtained in the coal mine.
 It lists the rules for holding\nbattles. For Link Battles, you may\nchoose which set of rules you wish\rto use.


### PR DESCRIPTION
restored these lines from main.

apparently sv just has placeholder data for TMs and HMs. in our case we have to have these provided for now because move descriptions have way shorter lines than the item description boxes want