### PR TITLE
Add Type Chart Rollback

### DIFF
--- a/armips/include/config.s
+++ b/armips/include/config.s
@@ -11,6 +11,12 @@ START_ADDRESS equ 0x0
 // if you do not want this change, then set it to 0
 FAIRY_TYPE_IMPLEMENTED equ 1
 
+// TYPE_EFFECTIVENESS_GEN defines the type chart interactions you would like to use.
+// Defining this as 5 or lower will revert Steel to resisting Ghost- and Dark-type moves.
+// Defining this as 1 will additionally make Bug super-effective on Poison and vice-versa, Psychic immune to Ghost, and Ice neutral against Fire.
+// This will NOT disable Dark or Steel type, nor revert move types (e.g. Bite).
+TYPE_EFFECTIVENESS_GEN equ GEN_LATEST
+
 // SNOW_WARNING_GENERATION controls whether to summon Snow or Hail when the ability is activated.
 // 9 or above: Snow
 // Otherwise: Hail

--- a/include/config.h
+++ b/include/config.h
@@ -7,6 +7,12 @@
 // set FAIRY_TYPE_IMPLEMENTED to 0 if you do not want this to happen
 #define FAIRY_TYPE_IMPLEMENTED 1
 
+// TYPE_EFFECTIVENESS_GEN defines the type chart interactions you would like to use.
+// Defining this as "5" or lower will revert Steel to resisting Ghost- and Dark-type moves.
+// Defining this as "1" will additionally make Bug super-effective on Poison and vice-versa, Psychic immune to Ghost, and Ice neutral against Fire.
+// This will NOT disable Dark or Steel type, nor revert move types (e.g. Bite).
+#define TYPE_EFFECTIVENESS_GEN GEN_LATEST
+
 // START_ADDRESS should be the same as armips/include/config.h's START_ADDRESS so that hall of fame/pokéathlon overworlds work properly.
 // START_ADDRESS defines the file address within the synthetic overlay where you would like to place all of the code that this project uses.  this is largely the repointed tables that the code uses.
 // if START_ADDRESS is 0x10000, then the tables will be inserted at address 0x10000 of the synthetic overlay

--- a/src/battle/battle_pokemon.c
+++ b/src/battle/battle_pokemon.c
@@ -73,6 +73,9 @@ u8 TypeEffectivenessTable[][3] =
 #endif
 
     { TYPE_POISON, TYPE_GRASS, 0x14 },
+#if TYPE_EFFECTIVENESS_GEN == 1
+    { TYPE_POISON, TYPE_BUG, 0x14 },
+#endif
     { TYPE_GROUND, TYPE_POISON, 0x14 },
     { TYPE_GROUND, TYPE_ROCK, 0x14 },
     { TYPE_GROUND, TYPE_BUG, 0x05 },
@@ -89,7 +92,11 @@ u8 TypeEffectivenessTable[][3] =
     { TYPE_ROCK, TYPE_ICE, 0x14 },
     { TYPE_BUG, TYPE_FIGHTING, 0x05 },
     { TYPE_BUG, TYPE_FLYING, 0x05 },
+#if TYPE_EFFECTIVENESS_GEN == 1
+    { TYPE_BUG, TYPE_POISON, 0x14 },
+#else
     { TYPE_BUG, TYPE_POISON, 0x05 },
+#endif
     { TYPE_BUG, TYPE_GHOST, 0x05 },
     { TYPE_BUG, TYPE_STEEL, 0x05 },
 
@@ -102,8 +109,13 @@ u8 TypeEffectivenessTable[][3] =
     { TYPE_BUG, TYPE_PSYCHIC, 0x14 },
     { TYPE_BUG, TYPE_DARK, 0x14 },
     { TYPE_GHOST, TYPE_GHOST, 0x14 },
+#if TYPE_EFFECTIVENESS_GEN > 1
     { TYPE_GHOST, TYPE_PSYCHIC, 0x14 },
+#endif
     { TYPE_GHOST, TYPE_DARK, 0x05 },
+#if TYPE_EFFECTIVENESS_GEN < 6
+    { TYPE_GHOST, TYPE_STEEL, 0x05 },
+#endif
     { TYPE_STEEL, TYPE_ROCK, 0x14 },
     { TYPE_STEEL, TYPE_STEEL, 0x05 },
 
@@ -162,7 +174,9 @@ u8 TypeEffectivenessTable[][3] =
     { TYPE_ICE, TYPE_FLYING, 0x14 },
     { TYPE_ICE, TYPE_GROUND, 0x14 },
     { TYPE_ICE, TYPE_STEEL, 0x05 },
+#if TYPE_EFFECTIVENESS_GEN > 1
     { TYPE_ICE, TYPE_FIRE, 0x05 },
+#endif
     { TYPE_ICE, TYPE_WATER, 0x05 },
     { TYPE_ICE, TYPE_GRASS, 0x14 },
     { TYPE_ICE, TYPE_ICE, 0x05 },
@@ -179,6 +193,9 @@ u8 TypeEffectivenessTable[][3] =
 
     { TYPE_DARK, TYPE_PSYCHIC, 0x14 },
     { TYPE_DARK, TYPE_DARK, 0x05 },
+#if TYPE_EFFECTIVENESS_GEN < 6
+    { TYPE_DARK, TYPE_STEEL, 0x05 },
+#endif
 
 // AI bugfix: move all of the immune type interactions to the end of the table so that the
 // immunities properly unset the super effective move effect flag (and a lanturn with thunderbolt
@@ -188,6 +205,9 @@ u8 TypeEffectivenessTable[][3] =
     { TYPE_GHOST, TYPE_NORMAL, 0x00 },
     { TYPE_ELECTRIC, TYPE_GROUND, 0x00 },
     { TYPE_PSYCHIC, TYPE_DARK, 0x00 },
+#if TYPE_EFFECTIVENESS_GEN == 1
+    { TYPE_GHOST, TYPE_PSYCHIC, 0x00 },
+#endif
 #if FAIRY_TYPE_IMPLEMENTED == 1
     { TYPE_DRAGON, TYPE_FAIRY, 0x00 },
 #endif


### PR DESCRIPTION
It has come to my attention that there is no toggle to revert type effectiveness to base game behaviour. Let's fix that.

In fact, let's go a step further and allow people to pull the type chart back as far as they want. Because why not? It's no real extra maintenance and future-proofs the system against potential type chart changes in Gen10+ (however unlikely they might be).