### PR TITLE
Fix to additional flags check in validate_trainers

### DIFF
--- a/scripts/validate_trainers_s.py
+++ b/scripts/validate_trainers_s.py
@@ -122,7 +122,7 @@ def parse_trainers(file_path):
 
 def mon_additional_flag_check(trainer, mon, mon_index, flag, key):
     has_additionalflags_flag = "additionalflags" in mon
-    has_flag = has_additionalflags_flag and flag in mon["additionalflags"]
+    has_flag = has_additionalflags_flag and flag.lower() in mon["additionalflags"]
     has_val = key in mon
 
     if has_flag and not has_val:


### PR DESCRIPTION
The validate_trainers script will fail on trainers that have additional flags set. The parser stores the flags in lowercase so this adjusts the check to work properly.