### PR TITLE
finish apricorn swap

### DIFF
--- a/data/text/222.txt
+++ b/data/text/222.txt
@@ -484,8 +484,8 @@ Silver Feather
 Rainbow Feather
 Mystery Egg
 Red Apricorn
-Blue Apricorn
 Yellow Apricorn
+Blue Apricorn
 Green Apricorn
 Pink Apricorn
 White Apricorn

--- a/data/text/830.txt
+++ b/data/text/830.txt
@@ -484,8 +484,8 @@ A strange feather that gleams with a\nsilvery color.
 A strange feather that gleams in\nrainbow colors.
 An Egg obtained from Mr. Pokémon. It\nhas a mysterious pattern on it, and\nwhat is in the Egg is unknown.
 A red Apricorn. It has a pungent\nscent that assails the nostrils.
-A blue Apricorn. It has a slightly\ngrassy smell to it.
 A yellow Apricorn. It has a light,\nrefreshing scent.
+A blue Apricorn. It has a slightly\ngrassy smell to it.
 A green Apricorn. It has a\nmysterious and aromatic scent.
 A pink Apricorn. It has a pleasantly\nsweet scent.
 A white Apricorn. It doesn’t have\nany aroma at all.

--- a/data/text/831.txt
+++ b/data/text/831.txt
@@ -484,8 +484,8 @@ a {COLOR 255}Silver Feather{COLOR 0}
 a {COLOR 255}Rainbow Feather{COLOR 0}
 a {COLOR 255}Mystery Egg{COLOR 0}
 a {COLOR 255}Red Apricorn{COLOR 0}
-a {COLOR 255}Blue Apricorn{COLOR 0}
 a {COLOR 255}Yellow Apricorn{COLOR 0}
+a {COLOR 255}Blue Apricorn{COLOR 0}
 a {COLOR 255}Green Apricorn{COLOR 0}
 a {COLOR 255}Pink Apricorn{COLOR 0}
 a {COLOR 255}White Apricorn{COLOR 0}

--- a/data/text/832.txt
+++ b/data/text/832.txt
@@ -484,8 +484,8 @@ None
 {COLOR 255}Rainbow Feathers{COLOR 0}
 {COLOR 255}Mystery Eggs{COLOR 0}
 {COLOR 255}Red Apricorns{COLOR 0}
-{COLOR 255}Blue Apricorns{COLOR 0}
 {COLOR 255}Yellow Apricorns{COLOR 0}
+{COLOR 255}Blue Apricorns{COLOR 0}
 {COLOR 255}Green Apricorns{COLOR 0}
 {COLOR 255}Pink Apricorns{COLOR 0}
 {COLOR 255}White Apricorns{COLOR 0}

--- a/data/text/833.txt
+++ b/data/text/833.txt
@@ -484,8 +484,8 @@ a {COLOR 255}Silver Feather{COLOR 0}
 a {COLOR 255}Rainbow Feather{COLOR 0}
 a {COLOR 255}Mystery Egg{COLOR 0}
 a {COLOR 255}Red Apricorn{COLOR 0}
-a {COLOR 255}Blue Apricorn{COLOR 0}
 a {COLOR 255}Yellow Apricorn{COLOR 0}
+a {COLOR 255}Blue Apricorn{COLOR 0}
 a {COLOR 255}Green Apricorn{COLOR 0}
 a {COLOR 255}Pink Apricorn{COLOR 0}
 a {COLOR 255}White Apricorn{COLOR 0}


### PR DESCRIPTION
move name/descriptions down to match current hgss ordering
<img width="518" height="252" alt="image" src="https://github.com/user-attachments/assets/edfa7756-88f0-4356-821a-c3d20a68621e" />
