### PR TITLE
add bytereplacement to allow for shop prices with 5 digits

### DIFF
--- a/bytereplacement
+++ b/bytereplacement
@@ -487,3 +487,5 @@ arm9 02082420 01 22
 # automatically starts the game.  does not care if there is a save or not
 arm9 02000E54 24 00 00 00 04 5C 1E 02
 #endif
+
+0031 0225DE46 05 23

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -564,7 +564,7 @@ def offset():
                 rom.close()
 
 
-OVERLAYS_TO_DECOMPRESS = [1, 2, 6, 7, 8, 10, 12, 14, 15, 18, 23, 61, 63, 64, 68, 94, 96, 112]
+OVERLAYS_TO_DECOMPRESS = [1, 2, 6, 7, 8, 10, 12, 14, 15, 18, 23, 31, 61, 63, 64, 68, 94, 96, 112]
 
 
 def decompress():


### PR DESCRIPTION
before:
<img width="500" height="376" alt="image" src="https://github.com/user-attachments/assets/e5aa8456-1e97-4327-93e1-9958d8fb8d20" />

after:
<img width="492" height="381" alt="image" src="https://github.com/user-attachments/assets/df916dfa-5a9e-41ed-bf0f-cca8c01f71ca" />
