### PR TITLE
remove extra blank line from apricorn text archive

### DIFF
--- a/data/text/021.txt
+++ b/data/text/021.txt
@@ -24,7 +24,6 @@ Skill Juice
 Jump Juice
 Speed Juice
 
-
 {STRVAR_1 51, 0, 0}
 Collected Apricorns are inside.
 Put the Apricorn in the Apriblender.


### PR DESCRIPTION
<img width="498" height="254" alt="image" src="https://github.com/user-attachments/assets/aff98ec5-6cac-4ea3-b84b-b2ae57f09e7b" />
<img width="498" height="312" alt="image" src="https://github.com/user-attachments/assets/42e2f0a0-4d70-4cc3-90c3-08f49636114d" />
<img width="486" height="410" alt="image" src="https://github.com/user-attachments/assets/ee58c472-5b8f-4ac2-ae49-29ebbe65ac5e" />
<img width="469" height="440" alt="image" src="https://github.com/user-attachments/assets/c67a41ae-d354-4791-995f-67b31e1e1f42" />

Surely