### PR TITLE
block unimplemented moves from trainers and level up learnsets

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -190,4 +190,8 @@
 // NATURAL_GIFT_POWER_GEN defines the power of Natural Gift based on generation. Gen 6 or higher are modernized values.
 #define NATURAL_GIFT_POWER_GEN GEN_LATEST
 
+// BLOCK_LEARNING_UNIMPLEMENTED_MOVES prevents learning moves that are not implemented
+// based on the move having FLAG_UNUSABLE_UNIMPLEMENTED
+#define BLOCK_LEARNING_UNIMPLEMENTED_MOVES
+
 #endif

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -1890,6 +1890,8 @@ u32 LONG_CALL GenerateShinyPIDKeepSubstructuresIntact(u32 otId, u32 pid);
  */
 u32 LONG_CALL GetMoveData(u16 id, u32 field);
 
+BOOL LONG_CALL IsMoveUnimplemented(u16 move);
+
 BOOL LONG_CALL Mon_UpdateRotomForm(struct PartyPokemon *mon, int form, int defaultSlot);
 
 void LONG_CALL Mon_UpdateShayminForm(struct PartyPokemon *mon, int form);

--- a/src/field/enemy_party.c
+++ b/src/field/enemy_party.c
@@ -346,6 +346,11 @@ void MakeTrainerPokemonParty(struct BATTLE_PARAM *bp, int num, int heapID)
         {
             for (j = 0; j < 4; j++)
             {
+#ifdef BLOCK_LEARNING_UNIMPLEMENTED_MOVES
+                if (IsMoveUnimplemented(moves[j])) {
+                    moves[j] = MOVE_NONE;
+                }
+#endif
                 SetPartyPokemonMoveAtPos(mons[i], moves[j], j);
             }
         }

--- a/src/moves.c
+++ b/src/moves.c
@@ -283,3 +283,18 @@ u32 LONG_CALL GetMoveData(u16 id, u32 field)
 
     return ret;
 }
+
+/**
+ *  @brief check if a move is unimplemented
+ *
+ *  @param move move ID to check
+ *  @return TRUE if move is unimplemented; FALSE otherwise
+ */
+BOOL LONG_CALL IsMoveUnimplemented(u16 move)
+{
+#ifdef BLOCK_LEARNING_UNIMPLEMENTED_MOVES
+    return (GetMoveData(move, MOVE_DATA_FLAGS) & FLAG_UNUSED_MOVE) != 0;
+#else
+    return FALSE;
+#endif
+}

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2380,7 +2380,12 @@ u32 MonTryLearnMoveOnLevelUp(struct PartyPokemon *mon, int * last_i, u16 * sp0)
     {
         *sp0 = LEVEL_UP_LEARNSET_MOVE(levelUpLearnset[*last_i]);
         (*last_i)++;
-        ret = TryAppendMonMove(mon, *sp0);
+#ifdef BLOCK_LEARNING_UNIMPLEMENTED_MOVES
+        if (!IsMoveUnimplemented(*sp0))
+#endif
+        {
+            ret = TryAppendMonMove(mon, *sp0);
+        }
     }
     sys_FreeMemoryEz(levelUpLearnset);
     return ret;
@@ -2629,4 +2634,24 @@ BOOL GetMonMachineMoveCompat(struct PartyPokemon *pp, u16 machineMoveIndex) {
  */
 void LONG_CALL LoadLevelUpLearnset_HandleAlternateForm(int species, int form, u32 *levelUpLearnset) {
     ArchiveDataLoadOfs(levelUpLearnset, ARC_LEVELUP_LEARNSETS, 0, PokeOtherFormMonsNoGet(species, form) * MAX_LEVELUP_MOVES * sizeof(u32), MAX_LEVELUP_MOVES * sizeof(u32));
+
+#ifdef BLOCK_LEARNING_UNIMPLEMENTED_MOVES
+    // shift moves to skip the unimplemented ones
+    int writeIndex = 0;
+    for (int readIndex = 0; readIndex < MAX_LEVELUP_MOVES; readIndex++) {
+        u32 entry = levelUpLearnset[readIndex];
+        u16 move = LEVEL_UP_LEARNSET_MOVE(entry);
+
+        if (move == LEVEL_UP_LEARNSET_END) {
+            levelUpLearnset[writeIndex] = entry;
+            break;
+        }
+
+        // keep the move
+        if (!IsMoveUnimplemented(move)) {
+            levelUpLearnset[writeIndex] = entry;
+            writeIndex++;
+        }
+    }
+#endif
 }


### PR DESCRIPTION
Testing:
- give a wild mon all unimplemented moves. config off = game hangs, config on = learned moves were not overwritten with unimplemented ones
- give trainer 3 unimplemented moves and a 5 pp move. config off = game hangs after 5 pp move is used up. config on = struggle after 