### PR TITLE
Disable Critical Health Bleeping

### DIFF
--- a/hooks
+++ b/hooks
@@ -588,3 +588,6 @@ arm9 PartyMenu_StartContextMenuButtonPressAnim_FromCursorObj 0207CB9C 3
 
 # determine rock smash table to use for items
 0001 DetermineRockSmashItem_hook 02204E28 1
+
+0012 BattleSystem_GetCriticalHpMusicFlag 0223BD2C 1
+0012 BattleSystem_SetCriticalHpMusicFlag 0223BD3C 1

--- a/include/battle.h
+++ b/include/battle.h
@@ -1680,9 +1680,9 @@ struct BattleSystem {
     // u8 unk240F_0:1;
     // u8 unk240F_1:1;
     // u8 unk240E_F:1;
-    // u8 criticalHpMusic:2;
-    // u8 criticalHpMusicDelay:3;
-    u8 padding[0x2400 - 0x2228];
+	u8 padding[0x2400 - 0x2218];
+    u8 criticalHpMusic:2;
+    u8 criticalHpMusicDelay:3;
     u32 terrain;
     u32 bgId;
     // int location;

--- a/include/config.h
+++ b/include/config.h
@@ -218,4 +218,8 @@
 // add or remove mythicals as you see fit
 #define VANILLA_MYTHICALS
 
+// DISABLE_CRITICAL_HP_WARNING should be used if you want to disable the warning whenever your pokemon is at critical health
+// comment out this line if you do not want this to happen
+//#define DISABLE_CRITICAL_HP_WARNING
+
 #endif

--- a/include/config.h
+++ b/include/config.h
@@ -220,6 +220,6 @@
 
 // DISABLE_CRITICAL_HP_WARNING should be used if you want to disable the warning whenever your pokemon is at critical health
 // comment out this line if you do not want this to happen
-//#define DISABLE_CRITICAL_HP_WARNING
+#define DISABLE_CRITICAL_HP_WARNING
 
 #endif

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -4149,10 +4149,18 @@ u32 LONG_CALL CheckSubstitute(struct BattleStruct* ctx, int client_no)
     return ret;
 }
 
-u8 BattleSystem_GetCriticalHpMusicFlag(struct BattleStruct *battleSystem UNUSED) {
+u8 BattleSystem_GetCriticalHpMusicFlag(struct BattleSystem *battleSystem) {
+	#ifdef DISABLE_CRITICAL_HP_WARNING
 	return 2;
+	#else
+	return battleSystem->criticalHpMusic;
+	#endif
 }
 
-u8 BattleSystem_SetCriticalHpMusicFlag(struct BattleStruct *battleSystem, u8 flag UNUSED) {
-	//battleSystem->criticalHpMusic = 2;
+u8 BattleSystem_SetCriticalHpMusicFlag(struct BattleSystem *battleSystem, u8 flag) {
+	#ifdef DISABLE_CRITICAL_HP_WARNING
+	battleSystem->criticalHpMusic = 2;
+	#else
+	battleSystem->criticalHpMusic = flag;
+	#endif
 }

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -4148,3 +4148,11 @@ u32 LONG_CALL CheckSubstitute(struct BattleStruct* ctx, int client_no)
 
     return ret;
 }
+
+u8 BattleSystem_GetCriticalHpMusicFlag(struct BattleStruct *battleSystem UNUSED) {
+	return 2;
+}
+
+u8 BattleSystem_SetCriticalHpMusicFlag(struct BattleStruct *battleSystem, u8 flag UNUSED) {
+	//battleSystem->criticalHpMusic = 2;
+}


### PR DESCRIPTION
I cant reproduce the 4 bleeps then fading away behavior from Gen VI onwards so its not an exact modernization but goddamn is it way better on the ears

https://github.com/user-attachments/assets/89297ef6-d562-4eeb-bddb-d3a0e0287634



