### PR TITLE
Fix fainted mons from same trainer

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -3719,7 +3719,7 @@ typedef enum Terrain {
 // For setting a Bitmask to flag trainer position on enemy/player side
 #define TRAINER_1     1 //0b01
 #define TRAINER_2     2 //0b10
-#define TRAINER_BOTH  (TRAINER_1 & TRAINER_2)
+#define TRAINER_BOTH  (TRAINER_1 | TRAINER_2)
 
 
 struct BattleSetupSub_138 {

--- a/src/battle/battle_script_commands.c
+++ b/src/battle/battle_script_commands.c
@@ -5306,7 +5306,32 @@ BOOL BtlCmd_TryFaintMon(struct BattleSystem *bsys, struct BattleStruct *ctx)
 
     int battlerId = GrabClientFromBattleScriptParam(bsys, ctx, read_battle_script_param(ctx));
 
-    if (ctx->battlemon[battlerId].hp == 0 && ctx->total_hinshi[battlerId] == 0) {
+    switch (battlerId) {
+    case BATTLER_PLAYER:
+        if (ctx->playerSideHasFaintedTeammateThisTurn & TRAINER_1) {
+            return FALSE;
+        }
+        break;
+    case BATTLER_PLAYER2:
+        if (ctx->playerSideHasFaintedTeammateThisTurn & TRAINER_2) {
+            return FALSE;
+        }
+        break;
+    case BATTLER_ENEMY:
+        if (ctx->enemySideHasFaintedTeammateThisTurn & TRAINER_1) {
+            return FALSE;
+        }
+        break;
+    case BATTLER_ENEMY2:
+        if (ctx->enemySideHasFaintedTeammateThisTurn & TRAINER_2) {
+            return FALSE;
+        }
+        break;
+    default:
+        break;
+    }
+
+    if (ctx->battlemon[battlerId].hp == 0) {
         ctx->fainting_client = battlerId;
         ctx->server_status_flag |= MaskOfFlagNo(battlerId) << BATTLE_STATUS_FAINTED_SHIFT;
         ctx->total_hinshi[battlerId]++;


### PR DESCRIPTION
`TryFaintMon` isn't run properly whenever a slot has a fainted mon.

Instead use `ctx->playerSideHasFaintedTeammateThisTurn` or `ctx->enemySideHasFaintedTeammateThisTurn` depending on which slot.

_hopefully this doesn't break something else_

Don't have a battle test, but I tested it in a single battle:
![melonDS_20260404-192246171](https://github.com/user-attachments/assets/d612fa08-19bd-4364-84c0-52d02d308e13)

See also: ``Test: Earthquake - faint message is not repeated for an already fainted battler``