### PR TITLE
Fix turning disable low health warning config off causing it to malfunction

### DIFF
--- a/hooks
+++ b/hooks
@@ -590,8 +590,8 @@ arm9 PartyMenu_StartContextMenuButtonPressAnim_FromCursorObj 0207CB9C 3
 # determine rock smash table to use for items
 0001 DetermineRockSmashItem_hook 02204E28 1
 
-0012 BattleSystem_GetCriticalHpMusicFlag 0223BD2C 1
-0012 BattleSystem_SetCriticalHpMusicFlag 0223BD3C 1
+0012 BattleSystem_GetCriticalHpMusicFlag 0223BD2C
+0012 BattleSystem_SetCriticalHpMusicFlag 0223BD3C
 
 0012 ov12_0224D23C 0224D23C 3
 0012 ov12_0224DD74 0224DD74 3

--- a/hooks
+++ b/hooks
@@ -590,8 +590,8 @@ arm9 PartyMenu_StartContextMenuButtonPressAnim_FromCursorObj 0207CB9C 3
 # determine rock smash table to use for items
 0001 DetermineRockSmashItem_hook 02204E28 1
 
-0012 BattleSystem_GetCriticalHpMusicFlag 0223BD2C
-0012 BattleSystem_SetCriticalHpMusicFlag 0223BD3C
+0012 BattleSystem_GetCriticalHpMusicFlag 0223BD2C 1
+0012 BattleSystem_SetCriticalHpMusicFlag 0223BD3C 2
 
 0012 ov12_0224D23C 0224D23C 3
 0012 ov12_0224DD74 0224DD74 3

--- a/include/config.h
+++ b/include/config.h
@@ -219,7 +219,7 @@
 #define VANILLA_MYTHICALS
 
 // DISABLE_CRITICAL_HP_WARNING should be used if you want to disable the warning whenever your pokemon is at critical health
-// comment out this line if you do not want this to happen
-#define DISABLE_CRITICAL_HP_WARNING
+// change this value to 0 if you do not want this to happen
+#define DISABLE_CRITICAL_HP_WARNING 1
 
 #endif

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -4171,7 +4171,7 @@ u32 LONG_CALL CheckSubstitute(struct BattleStruct *ctx, int client_no)
     return ret;
 }
 
-u8 BattleSystem_GetCriticalHpMusicFlag(struct BattleSystem *battleSystem UNUSED) {
+u8 BattleSystem_GetCriticalHpMusicFlag(struct BattleSystem *battleSystem) {
 	#ifdef DISABLE_CRITICAL_HP_WARNING
 	return 2;
 	#else
@@ -4179,7 +4179,7 @@ u8 BattleSystem_GetCriticalHpMusicFlag(struct BattleSystem *battleSystem UNUSED)
 	#endif
 }
 
-void BattleSystem_SetCriticalHpMusicFlag(struct BattleSystem *battleSystem, u8 flag UNUSED) {
+void BattleSystem_SetCriticalHpMusicFlag(struct BattleSystem *battleSystem, u8 flag) {
 	#ifdef DISABLE_CRITICAL_HP_WARNING
 	battleSystem->criticalHpMusic = 2;
 	#else

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -4172,7 +4172,7 @@ u32 LONG_CALL CheckSubstitute(struct BattleStruct *ctx, int client_no)
 }
 
 u8 BattleSystem_GetCriticalHpMusicFlag(struct BattleSystem *battleSystem) {
-	#ifdef DISABLE_CRITICAL_HP_WARNING
+	#if DISABLE_CRITICAL_HP_WARNING == 1
 	return 2;
 	#else
 	return battleSystem->criticalHpMusic;
@@ -4180,7 +4180,7 @@ u8 BattleSystem_GetCriticalHpMusicFlag(struct BattleSystem *battleSystem) {
 }
 
 void BattleSystem_SetCriticalHpMusicFlag(struct BattleSystem *battleSystem, u8 flag) {
-	#ifdef DISABLE_CRITICAL_HP_WARNING
+	#if DISABLE_CRITICAL_HP_WARNING == 1
 	battleSystem->criticalHpMusic = 2;
 	#else
 	battleSystem->criticalHpMusic = flag;


### PR DESCRIPTION
I guess those shouldnt be unused, because they are used when the config is disabled