### PR TITLE
battle: add Blood Moon repeat-use restriction

### DIFF
--- a/data/battle_tests/moves/blood_moon/repeat_use.c
+++ b/data/battle_tests/moves/blood_moon/repeat_use.c
@@ -1,0 +1,110 @@
+// Test: Blood Moon - cannot be used twice in a row
+#ifndef GET_TEST_CASE_ONLY
+
+#include "../../../../include/battle.h"
+#include "../../../../include/constants/ability.h"
+#include "../../../../include/constants/item.h"
+#include "../../../../include/constants/moves.h"
+#include "../../../../include/constants/species.h"
+#include "../../../../include/test_battle.h"
+
+// each test file is a separate .c file in battle_tests/ for better organization
+const struct TestBattleScenario BattleTests[] = {
+
+#endif
+
+    {
+        .battleType = BATTLE_TYPE_SINGLE,
+        .weather = WEATHER_NONE,
+        .fieldCondition = 0,
+        .terrain = TERRAIN_NONE,
+        .playerParty = {
+            {
+                .species = SPECIES_URSALUNA,
+                .level = 50,
+                .form = 0,
+                .ability = ABILITY_MINDS_EYE,
+                .item = ITEM_NONE,
+                .moves = { MOVE_BLOOD_MOON, MOVE_NONE, MOVE_NONE, MOVE_NONE },
+                .hp = FULL_HP,
+                .status = 0,
+                .condition2 = 0,
+                .moveEffectFlags = 0,
+            },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE }
+        },
+        .enemyParty = {
+            {
+                .species = SPECIES_SHUCKLE,
+                .level = 50,
+                .form = 0,
+                .ability = ABILITY_STURDY,
+                .item = ITEM_NONE,
+                .moves = { MOVE_SLEEP_TALK, MOVE_NONE, MOVE_NONE, MOVE_NONE },
+                .hp = FULL_HP,
+                .status = 0,
+                .condition2 = 0,
+                .moveEffectFlags = 0,
+            },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE }
+        },
+        .playerScript = {
+            {
+                { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_FIRST },
+                { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_FIRST },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            },
+            {
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            }
+        },
+        .enemyScript = {
+            {
+                { ACTION_MOVE_SLOT_1, BATTLER_PLAYER_FIRST },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            },
+            {
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            }
+        },
+        .expectations = {
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "Ursaluna used Blood Moon!" },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "You can't use Blood Moon twice in a row!" },
+        }
+    },
+#ifndef GET_TEST_CASE_ONLY
+};
+#endif

--- a/src/battle/other_battle_calculators.c
+++ b/src/battle/other_battle_calculators.c
@@ -3466,9 +3466,11 @@ u32 LONG_CALL StruggleCheck(struct BattleSystem *bsys, struct BattleStruct *ctx,
             }
         }
         if (struggleCheckFlags & STRUGGLE_CHECK_GIGATON_HAMMER) {
-            // Encore allows Gigaton Hammer to be used twice in a row, but on subsequent turns of the Encore the user will be forced to Struggle.
+            // Encore allows these moves to be used twice in a row, but on subsequent turns of the Encore the user will be forced to Struggle.
             if (!(ctx->battlemon[battlerId].moveeffect.encoredMove && ctx->battlemon[battlerId].moveeffect.encoredTurns == 3)) {
-                if (ctx->waza_no_old[battlerId] == ctx->battlemon[battlerId].move[movePos] && ctx->waza_no_old[battlerId] == MOVE_GIGATON_HAMMER) {
+                if (ctx->waza_no_old[battlerId] == ctx->battlemon[battlerId].move[movePos]
+                 && (ctx->waza_no_old[battlerId] == MOVE_GIGATON_HAMMER
+                  || ctx->waza_no_old[battlerId] == MOVE_BLOOD_MOON)) {
                     nonSelectableMoves |= No2Bit(movePos);
                 }
             }


### PR DESCRIPTION
## Summary

This PR adds `MOVE_BLOOD_MOON` to the existing Gigaton Hammer repeat-use restriction path.

HG-Engine already has selector logic that prevents Gigaton Hammer from being selected twice in a row. Blood Moon uses the same modern restriction, so this change extends that existing check instead of adding a separate move-history system.

## Changes

- Adds `MOVE_BLOOD_MOON` to the existing `STRUGGLE_CHECK_GIGATON_HAMMER` restriction check.
- Preserves the existing Encore exception behavior.
- Updates the nearby comment so it refers to both restricted moves instead of only Gigaton Hammer.

## Scope

Included:
- `src/battle/other_battle_calculators.c`
- Blood Moon repeat-use selector restriction only

Not included:
- No ROM files
- No save files
- No generated build outputs
- No debug/test artifacts
- No unrelated modern move or ability changes

## Testing / Proof Level

- Source change implemented: yes
- Build run in this clean PR clone: no
- Reason build was not run: this clean PR clone does not include `rom.nds` or generated ROM files
- Runtime/emulator behavior verified: no
- Runtime gauntlet proven: no

## Notes

This is intended as a small, reviewable modern move behavior PR. Full runtime validation should still be handled through the project’s normal battle-test or test-room process.