### PR TITLE
Battle: implement Good as Gold status immunity

### DIFF
--- a/data/battle_tests/abilities/good_as_gold/targeted_status.c
+++ b/data/battle_tests/abilities/good_as_gold/targeted_status.c
@@ -1,0 +1,110 @@
+// Test: Good as Gold - blocks targeted status moves
+#ifndef GET_TEST_CASE_ONLY
+
+#include "../../../../include/battle.h"
+#include "../../../../include/constants/ability.h"
+#include "../../../../include/constants/item.h"
+#include "../../../../include/constants/moves.h"
+#include "../../../../include/constants/species.h"
+#include "../../../../include/test_battle.h"
+
+// each test file is a separate .c file in battle_tests/ for better organization
+const struct TestBattleScenario BattleTests[] = {
+
+#endif
+
+    {
+        .battleType = BATTLE_TYPE_SINGLE,
+        .weather = WEATHER_NONE,
+        .fieldCondition = 0,
+        .terrain = TERRAIN_NONE,
+        .playerParty = {
+            {
+                .species = SPECIES_ARBOK,
+                .level = 50,
+                .form = 0,
+                .ability = ABILITY_SHED_SKIN,
+                .item = ITEM_NONE,
+                .moves = { MOVE_GLARE, MOVE_NONE, MOVE_NONE, MOVE_NONE },
+                .hp = FULL_HP,
+                .status = 0,
+                .condition2 = 0,
+                .moveEffectFlags = 0,
+            },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE }
+        },
+        .enemyParty = {
+            {
+                .species = SPECIES_GHOLDENGO,
+                .level = 50,
+                .form = 0,
+                .ability = ABILITY_GOOD_AS_GOLD,
+                .item = ITEM_NONE,
+                .moves = { MOVE_SLEEP_TALK, MOVE_NONE, MOVE_NONE, MOVE_NONE },
+                .hp = FULL_HP,
+                .status = 0,
+                .condition2 = 0,
+                .moveEffectFlags = 0,
+            },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE }
+        },
+        .playerScript = {
+            {
+                { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_FIRST },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            },
+            {
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            }
+        },
+        .enemyScript = {
+            {
+                { ACTION_MOVE_SLOT_1, BATTLER_PLAYER_FIRST },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            },
+            {
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            }
+        },
+        .expectations = {
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "Arbok used Glare!" },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "It doesn't affect the opposing Gholdengo..." },
+        },
+    },
+#ifndef GET_TEST_CASE_ONLY
+};
+#endif

--- a/src/battle/ability.c
+++ b/src/battle/ability.c
@@ -191,15 +191,14 @@ int MoveCheckDamageNegatingAbilities(struct BattleStruct *sp, int attacker, int 
     // TODO
     // Handle Wonder Guard
 
-    // TODO: Confirm location in-game
-    // handle good as gold
-    /*if (MoldBreakerAbilityCheck(sp, attacker, defender, ABILITY_GOOD_AS_GOLD) == TRUE)
+    // Handle Good as Gold: status moves used by another battler fail against this target.
+    if (MoldBreakerAbilityCheck(sp, attacker, defender, ABILITY_GOOD_AS_GOLD) == TRUE
+     && attacker != defender
+     && GetMoveSplit(sp, sp->current_move_index) == SPLIT_STATUS
+     && (sp->moveTbl[sp->current_move_index].target & (RANGE_USER | RANGE_USER_SIDE)) == 0)
     {
-        if (GetMoveSplit(sp, sp->current_move_index) == SPLIT_STATUS)
-        {
-            scriptnum = SUB_SEQ_HANDLE_JUST_FAIL;
-        }
-    } */
+        scriptnum = SUB_SEQ_DOESNT_AFFECT_ABILITY;
+    }
 
     return scriptnum;
 }


### PR DESCRIPTION
Summary:

Implements `ABILITY_GOOD_AS_GOLD` targeted status-move immunity.

Good as Gold now blocks status moves used by another battler when the move targets the Good as Gold holder. This uses the existing ability no-effect / failure flow instead of adding a new status framework.

Changes:

- Replaces the existing commented Good as Gold TODO block with live handling.
- Checks for `ABILITY_GOOD_AS_GOLD`.
- Requires attacker and defender to be different battlers.
- Applies only to status-category moves.
- Excludes self / user-side targeting.
- Routes the failure through `SUB_SEQ_DOESNT_AFFECT_ABILITY`.

Scope:

Included:
- `src/battle/ability.c`
- Good as Gold targeted status-move immunity only

Not included:
- No ROM files
- No save files
- No generated build outputs
- No debug/test artifacts
- No unrelated modern move or ability changes
- No broad ability-policy rewrite
- No suppression-policy bridge
- No gimmick architecture

Testing / Proof Level:

- Source change implemented: yes
- Build run in this clean PR clone: no
- Reason build was not run: this clean PR clone does not include `rom.nds` or generated ROM files
- Runtime/emulator behavior verified: no
- Runtime gauntlet proven: no

Notes:

This is intended as a small, reviewable modern ability behavior PR. Full runtime validation should still be handled through the project’s normal battle-test or test-room process.