### PR TITLE
allow all dumps to complete if one fails

### DIFF
--- a/data/Headbutt.c
+++ b/data/Headbutt.c
@@ -5174,7 +5174,7 @@ const HeadbuttArchiveData __data =
 
     .route34 = {
         .normalTreeCount = 15,
-        .specialTreeCount = 1,
+        .specialTreeCount = 0,
         .normalSlots =
         {
             { SPECIES_HOOTHOOT, 9, 10 },

--- a/dump.mk
+++ b/dump.mk
@@ -1,4 +1,4 @@
-.PHONY: dumprom dump_prepare dump_learnsets dump_narc_data dump_armips_data dump_hidden_items dump_trainernames dump_clean_work dump_reset check_dump_rom
+.PHONY: dumprom dump_prepare dump_learnsets dump_narc_data dump_armips_data dump_trainernames dump_clean_work dump_reset check_dump_rom
 
 DUMP_SCRIPT_LOCATION := tools/source/dumptools
 DUMP_WORKDIRS := $(BUILD_NARC) $(BUILD)/a028
@@ -41,9 +41,6 @@ dump_narc_data: dump_prepare
 dump_armips_data: dump_trainernames
 	$(PYTHON) $(DUMP_SCRIPT_LOCATION)/dump_narcs.py "$(DUMP_ROM)" armips
 
-dump_hidden_items: dump_prepare
-	$(PYTHON) $(DUMP_SCRIPT_LOCATION)/dump_scripts/hidden_items.py
-
 dump_clean_work:
 	rm -rf $(BUILD)
 
@@ -61,6 +58,5 @@ dumprom: check_dump_rom
 	else \
 		$(MAKE) dump_narc_data DUMP_ROM="$(DUMP_ROM)" DUMP_MODE="$(DUMP_MODE)"; \
 	fi
-	$(MAKE) dump_hidden_items DUMP_ROM="$(DUMP_ROM)"
 	$(MAKE) dump_clean_work
 	@echo "Done. See output in dumped_$(DUMP_MODE)/, learnsets are already in data/learnsets/learnsets.json."

--- a/include/trainer_data.h
+++ b/include/trainer_data.h
@@ -45,6 +45,8 @@ typedef uint32_t u32;
 #define TRAINER_DATA_EXTRA_TYPE_PP_COUNTS 0x80
 #define TRAINER_DATA_EXTRA_TYPE_NICKNAME  0x100
 
+#define TRAINER_DATA_RANDOM_PARTY_ORDER 0x80
+
 #define F_PRIORITIZE_SUPER_EFFECTIVE (1 << 0)
 #define F_EVALUATE_ATTACKS           (1 << 1)
 #define F_EXPERT_ATTACKS             (1 << 2)

--- a/src/field/enemy_party.c
+++ b/src/field/enemy_party.c
@@ -86,7 +86,7 @@ void MakeTrainerPokemonParty(struct BATTLE_PARAM *bp, int num, int heapID)
     }
 
     u8 pokecount = bp->trainer_data[num].poke_count;
-    u8 randomorder_flag = pokecount & 0x80;
+    u8 randomorder_flag = pokecount & TRAINER_DATA_RANDOM_PARTY_ORDER;
     pokecount &= 0x7f;
 
     // goal:  get rid of massive switch statement with each individual byte.  make the trainer type a bitfield

--- a/tools/source/dumptools/dump_narcs.py
+++ b/tools/source/dumptools/dump_narcs.py
@@ -10,7 +10,7 @@ from dump_scripts.encounters import dump_encounters_c
 from dump_scripts.evodata import dump_evodata_c
 from dump_scripts.headbutt import dump_headbutt_c
 from dump_scripts.height_table import dump_heighttable_c
-from dump_scripts.hidden_items import dump_hidden_items_c
+from dump_scripts.hidden_items import INPUT_PATH as HIDDEN_ITEMS_ARM9_PATH, dump_hidden_items_from_arm9_c
 from dump_scripts.mondata import dump_mondata
 from dump_scripts.moves import dump_moves_c
 from dump_scripts.pokedex_data import dump_pokedex_area_files, dump_pokedex_sort_files
@@ -88,12 +88,6 @@ def dump_armips_outputs(mondata_narc, rom, expanded):
     return failures
 
 
-def dump_hidden_item_outputs(rom):
-    os.makedirs("dumped_c", exist_ok=True)
-    code_addons_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/0/2/8"]])
-    write_dump("./dumped_c/HiddenItems.c", dump_hidden_items_c(code_addons_narc.files[18], input_name="a/0/2/8:18"))
-
-
 def dump_c_outputs(rom, mondata_raw_narc, msgdata_narc, pokedexsort_narc, expanded):
     os.makedirs("dumped_c", exist_ok=True)
     failures = []
@@ -112,7 +106,7 @@ def dump_c_outputs(rom, mondata_raw_narc, msgdata_narc, pokedexsort_narc, expand
     run_dump("Headbutt.c", failures, lambda: dump_headbutt_c(ndspy.narc.NARC(rom.files[rom.filenames["a/2/5/2"]]).files, "./dumped_c/Headbutt.c"))
     run_dump("SafariEncounters.c", failures, lambda: write_dump("./dumped_c/SafariEncounters.c", dump_safari_encounters_c(ndspy.narc.NARC(rom.files[rom.filenames["a/2/3/0"]]), expanded)))
     run_dump("Trainers.c", failures, lambda: write_dump("./dumped_c/Trainers.c", dump_trainerdata_c(rom, msgdata_narc, expanded)))
-    run_dump("HiddenItems.c", failures, lambda: dump_hidden_item_outputs(rom))
+    run_dump("HiddenItems.c", failures, lambda: write_dump("./dumped_c/HiddenItems.c", dump_hidden_items_from_arm9_c(HIDDEN_ITEMS_ARM9_PATH.read_bytes())))
 
     return failures
 
@@ -135,7 +129,7 @@ def main(argv):
 
     if mode == "armips":
         failures = dump_armips_outputs(mondata_narc, rom, expanded)
-        run_dump("HiddenItems.c", failures, lambda: dump_hidden_item_outputs(rom))
+        run_dump("HiddenItems.c", failures, lambda: write_dump("./dumped_c/HiddenItems.c", dump_hidden_items_from_arm9_c(HIDDEN_ITEMS_ARM9_PATH.read_bytes())))
         if failures:
             print(f"Completed with {len(failures)} failed dump(s): {', '.join(failures)}", file=sys.stderr)
             return 1

--- a/tools/source/dumptools/dump_narcs.py
+++ b/tools/source/dumptools/dump_narcs.py
@@ -10,6 +10,7 @@ from dump_scripts.encounters import dump_encounters_c
 from dump_scripts.evodata import dump_evodata_c
 from dump_scripts.headbutt import dump_headbutt_c
 from dump_scripts.height_table import dump_heighttable_c
+from dump_scripts.hidden_items import dump_hidden_items_c
 from dump_scripts.mondata import dump_mondata
 from dump_scripts.moves import dump_moves_c
 from dump_scripts.pokedex_data import dump_pokedex_area_files, dump_pokedex_sort_files
@@ -54,69 +55,66 @@ def remove_stale_outputs(paths):
             os.remove(stale_path)
 
 
+def run_dump(name, failures, callback):
+    try:
+        callback()
+    except Exception as error:
+        failures.append(name)
+        print(f"Failed to dump {name}: {error}", file=sys.stderr)
+
+
+def write_dump(path, contents):
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(contents)
+
+
+def dump_armips_trainers(rom, expanded):
+    trdata_narc = dump_narc(rom, "a/0/5/5", TRDATA_NARC_FORMAT)
+    trpok_narc = dump_trpok_narc(rom, "a/0/5/6", trdata_narc)
+    write_dump("./dumped_armips/trainers.s", dump_trainerdata(trdata_narc, trpok_narc, expanded))
+
+
 def dump_armips_outputs(mondata_narc, rom, expanded):
     os.makedirs("dumped_armips", exist_ok=True)
     remove_stale_outputs(ARMIPS_STALE_PATHS)
+    failures = []
 
     if not os.path.exists("build/trainernames.txt"):
         print("armips mode requires build/trainernames.txt; run dump_trainernames first", file=sys.stderr)
         raise SystemExit(1)
 
-    with open("./dumped_armips/mondata.s", "w", encoding="utf-8") as file:
-        file.write(dump_mondata(mondata_narc))
+    run_dump("mondata.s", failures, lambda: write_dump("./dumped_armips/mondata.s", dump_mondata(mondata_narc)))
+    run_dump("trainers.s", failures, lambda: dump_armips_trainers(rom, expanded))
+    return failures
 
-    trdata_narc = dump_narc(rom, "a/0/5/5", TRDATA_NARC_FORMAT)
-    trpok_narc = dump_trpok_narc(rom, "a/0/5/6", trdata_narc)
-    with open("./dumped_armips/trainers.s", "w", encoding="utf-8") as file:
-        file.write(dump_trainerdata(trdata_narc, trpok_narc, expanded))
+
+def dump_hidden_item_outputs(rom):
+    os.makedirs("dumped_c", exist_ok=True)
+    code_addons_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/0/2/8"]])
+    write_dump("./dumped_c/HiddenItems.c", dump_hidden_items_c(code_addons_narc.files[18], input_name="a/0/2/8:18"))
 
 
 def dump_c_outputs(rom, mondata_raw_narc, msgdata_narc, pokedexsort_narc, expanded):
     os.makedirs("dumped_c", exist_ok=True)
+    failures = []
 
-    with open("./dumped_c/Species.c", "w", encoding="utf-8") as file:
-        file.write(dump_species_data(mondata_raw_narc, msgdata_narc, pokedexsort_narc))
+    # callback wrapper around each dump so we don't fast-fail on first error
+    run_dump("Species.c", failures, lambda: write_dump("./dumped_c/Species.c", dump_species_data(mondata_raw_narc, msgdata_narc, pokedexsort_narc)))
+    run_dump("Moves.c", failures, lambda: write_dump("./dumped_c/Moves.c", dump_moves_c(dump_narc(rom, "a/0/1/1", MOVE_NARC_FORMAT), msgdata_narc)))
+    run_dump("Encounters.c", failures, lambda: write_dump("./dumped_c/Encounters.c", dump_encounters_c(dump_narc(rom, "a/0/3/7", ENCOUNTER_NARC_FORMAT), expanded)))
+    run_dump("Evolutions.c", failures, lambda: write_dump("./dumped_c/Evolutions.c", dump_evodata_c(dump_narc(rom, "a/0/3/4", EXPANDED_EVO_NARC_FORMAT if expanded else EVO_NARC_FORMAT), expanded)))
+    run_dump("RegionalDex.c", failures, lambda: write_dump("./dumped_c/RegionalDex.c", dump_regionaldex_c(ndspy.narc.NARC(rom.files[rom.filenames["a/1/3/8"]]).files[0])))
+    run_dump("BabyMons.c", failures, lambda: write_dump("./dumped_c/BabyMons.c", dump_babymons_c(rom.files[rom.filenames["poketool/personal/pms.narc"]])))
+    run_dump("HeightTable.c", failures, lambda: dump_heighttable_c(ndspy.narc.NARC(rom.files[rom.filenames["a/0/0/5"]]).files, "./dumped_c/HeightTable.c"))
+    run_dump("SpriteOffsets.c", failures, lambda: write_dump("./dumped_c/SpriteOffsets.c", dump_spriteoffsets_c(ndspy.narc.NARC(rom.files[rom.filenames["a/1/8/0"]]).files[0])))
+    run_dump("PokedexSort.c", failures, lambda: dump_pokedex_sort_files(pokedexsort_narc.files, "./dumped_c"))
+    run_dump("PokedexArea.c", failures, lambda: dump_pokedex_area_files(ndspy.narc.NARC(rom.files[rom.filenames["a/1/3/3"]]).files, "./dumped_c"))
+    run_dump("Headbutt.c", failures, lambda: dump_headbutt_c(ndspy.narc.NARC(rom.files[rom.filenames["a/2/5/2"]]).files, "./dumped_c/Headbutt.c"))
+    run_dump("SafariEncounters.c", failures, lambda: write_dump("./dumped_c/SafariEncounters.c", dump_safari_encounters_c(ndspy.narc.NARC(rom.files[rom.filenames["a/2/3/0"]]), expanded)))
+    run_dump("Trainers.c", failures, lambda: write_dump("./dumped_c/Trainers.c", dump_trainerdata_c(rom, msgdata_narc, expanded)))
+    run_dump("HiddenItems.c", failures, lambda: dump_hidden_item_outputs(rom))
 
-    moves_narc = dump_narc(rom, "a/0/1/1", MOVE_NARC_FORMAT)
-    with open("./dumped_c/Moves.c", "w", encoding="utf-8") as file:
-        file.write(dump_moves_c(moves_narc, msgdata_narc))
-
-    encounters_narc = dump_narc(rom, "a/0/3/7", ENCOUNTER_NARC_FORMAT)
-    with open("./dumped_c/Encounters.c", "w", encoding="utf-8") as file:
-        file.write(dump_encounters_c(encounters_narc, expanded))
-
-    evodata_narc = dump_narc(rom, "a/0/3/4", EXPANDED_EVO_NARC_FORMAT if expanded else EVO_NARC_FORMAT)
-    with open("./dumped_c/Evolutions.c", "w", encoding="utf-8") as file:
-        file.write(dump_evodata_c(evodata_narc, expanded))
-
-    regionaldex_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/1/3/8"]])
-    with open("./dumped_c/RegionalDex.c", "w", encoding="utf-8") as file:
-        file.write(dump_regionaldex_c(regionaldex_narc.files[0]))
-
-    with open("./dumped_c/BabyMons.c", "w", encoding="utf-8") as file:
-        file.write(dump_babymons_c(rom.files[rom.filenames["poketool/personal/pms.narc"]]))
-
-    heighttable_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/0/0/5"]])
-    dump_heighttable_c(heighttable_narc.files, "./dumped_c/HeightTable.c")
-
-    spriteoffsets_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/1/8/0"]])
-    with open("./dumped_c/SpriteOffsets.c", "w", encoding="utf-8") as file:
-        file.write(dump_spriteoffsets_c(spriteoffsets_narc.files[0]))
-
-    dump_pokedex_sort_files(pokedexsort_narc.files, "./dumped_c")
-
-    pokedexarea_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/1/3/3"]])
-    dump_pokedex_area_files(pokedexarea_narc.files, "./dumped_c")
-
-    headbutt_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/2/5/2"]])
-    dump_headbutt_c(headbutt_narc.files, "./dumped_c/Headbutt.c")
-
-    safari_encounters_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/2/3/0"]])
-    with open("./dumped_c/SafariEncounters.c", "w", encoding="utf-8") as file:
-        file.write(dump_safari_encounters_c(safari_encounters_narc, expanded))
-
-    with open("./dumped_c/Trainers.c", "w", encoding="utf-8") as file:
-        file.write(dump_trainerdata_c(rom, msgdata_narc, expanded))
+    return failures
 
 
 def main(argv):
@@ -136,12 +134,27 @@ def main(argv):
         print("HG Engine Rom detected")
 
     if mode == "armips":
-        dump_armips_outputs(mondata_narc, rom, expanded)
+        failures = dump_armips_outputs(mondata_narc, rom, expanded)
+        run_dump("HiddenItems.c", failures, lambda: dump_hidden_item_outputs(rom))
+        if failures:
+            print(f"Completed with {len(failures)} failed dump(s): {', '.join(failures)}", file=sys.stderr)
+            return 1
         return 0
 
-    msgdata_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/0/2/7"]])
-    pokedexsort_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/2/1/4"]])
-    dump_c_outputs(rom, mondata_raw_narc, msgdata_narc, pokedexsort_narc, expanded)
+    msgdata_narc = None
+    pokedexsort_narc = None
+    try:
+        msgdata_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/0/2/7"]])
+    except Exception as error:
+        print(f"Failed to load msg_data.narc: {error}", file=sys.stderr)
+    try:
+        pokedexsort_narc = ndspy.narc.NARC(rom.files[rom.filenames["a/2/1/4"]])
+    except Exception as error:
+        print(f"Failed to load pokedex sort narc: {error}", file=sys.stderr)
+    failures = dump_c_outputs(rom, mondata_raw_narc, msgdata_narc, pokedexsort_narc, expanded)
+    if failures:
+        print(f"Completed with {len(failures)} failed dump(s): {', '.join(failures)}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tools/source/dumptools/dump_scripts/dump_tools.py
+++ b/tools/source/dumptools/dump_scripts/dump_tools.py
@@ -7,6 +7,7 @@ from typing import Dict, DefaultDict
 from collections import defaultdict
 import ndspy
 import ndspy.rom, ndspy.narc
+import ndspy.codeCompression
 import copy
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -142,6 +143,8 @@ ENCOUNTER_NARC_FORMAT = [
     [2, "padding"]]
 
 TRDATA_FLAGS =["has_moves", "has_items", "set_abilities", "set_ball", "set_iv_ev", "set_nature", "shiny_lock", "additional_flags"]
+TRAINER_RANDOM_PARTY_ORDER_FLAG = 0x80
+TRAINER_PARTY_SIZE_MASK = 0x7F
 
 for n in range(0,12):
     ENCOUNTER_NARC_FORMAT.append([1, f'walking_{n}_level'])
@@ -186,6 +189,14 @@ def read_narc_data(data, narc_format):
 def read_bytes(stream, n):
     return int.from_bytes(stream.read(n), 'little')
 
+def read_arm9_table(arm9_data, offset, size):
+    table_end = offset + size
+    if len(arm9_data) < table_end:
+        arm9_data = ndspy.codeCompression.decompress(arm9_data)
+    if len(arm9_data) < table_end:
+        raise ValueError(f"arm9.bin is too small for table at 0x{offset:X}")
+    return arm9_data[offset:table_end]
+
 def dump_narc(rom, narc_path, narc_format):
     parsed_narc_data = []
 
@@ -217,7 +228,7 @@ def dump_trpok_narc(rom, narc_path, trdata_narc):
     # use supplied format to parse each file in narc
     for idx, data in enumerate(narc.files):
         flags = bin(trdata_narc[idx]["flags"])[2:].zfill(8)
-        num_pokemon = trdata_narc[idx]["num_pokemon"]
+        num_pokemon = trdata_narc[idx]["num_pokemon"] & TRAINER_PARTY_SIZE_MASK
         parsed_narc_data[idx] = {}
         stream = io.BytesIO(data)
         for i in range(0, num_pokemon):

--- a/tools/source/dumptools/dump_scripts/headbutt.py
+++ b/tools/source/dumptools/dump_scripts/headbutt.py
@@ -2,9 +2,27 @@ from pathlib import Path
 
 from dump_scripts.dump_tools import lookup_species
 
+HEADBUTT_DATA_PATH = Path("data/Headbutt.c")
+
 
 def _species_name(species):
     return lookup_species(species)
+
+
+def load_headbutt_file_names(path, expected_count):
+    if not path.exists():
+        return None
+
+    names = []
+    for line in path.read_text(encoding="ascii").splitlines():
+        line = line.strip()
+        prefix = "typedef struct PACKED HeadbuttFile_"
+        if line.startswith(prefix):
+            names.append(line[len(prefix):line.index(" {")])
+
+    if len(names) != expected_count:
+        return None
+    return names
 
 
 def dump_headbutt(files):
@@ -108,15 +126,19 @@ def dump_headbutt_single_c(files, output_path, file_names=None):
     used_field_names = set()
 
     for index, data in enumerate(files):
-        stem = f"{index:03d}" if file_names is None else file_names[index]
-        type_name = f"HeadbuttFile_{stem}"
-        raw_name = stem.split("_", 1)[1] if "_" in stem else stem
-        parts = [part for part in raw_name.split("_") if part]
-        if not parts:
+        if file_names is None:
+            stem = f"{index:03d}"
             field_name = f"entry{index:03d}"
         else:
-            field_name = parts[0].lower() + "".join(part[:1].upper() + part[1:] for part in parts[1:])
-            field_name = field_name.replace("Pokmon", "Pokemon")
+            stem = file_names[index]
+            raw_name = stem.split("_", 1)[1] if "_" in stem else stem
+            parts = [part for part in raw_name.split("_") if part]
+            if not parts:
+                field_name = f"entry{index:03d}"
+            else:
+                field_name = parts[0].lower() + "".join(part[:1].upper() + part[1:] for part in parts[1:])
+                field_name = field_name.replace("Pokmon", "Pokemon")
+        type_name = f"HeadbuttFile_{stem}"
         if field_name in used_field_names:
             field_name = f"{field_name}{index:03d}"
         used_field_names.add(field_name)
@@ -169,6 +191,7 @@ def dump_headbutt_single_c(files, output_path, file_names=None):
         lines.append("")
 
     lines.extend([
+        "",
         "typedef struct PACKED HeadbuttArchiveData {",
     ])
 
@@ -177,6 +200,7 @@ def dump_headbutt_single_c(files, output_path, file_names=None):
 
     lines.extend([
         "} HeadbuttArchiveData;",
+        "",
         "",
     ])
 
@@ -244,4 +268,4 @@ def dump_headbutt_single_c(files, output_path, file_names=None):
 
 
 def dump_headbutt_c(files, output_path):
-    dump_headbutt_single_c(files, output_path)
+    dump_headbutt_single_c(files, output_path, load_headbutt_file_names(HEADBUTT_DATA_PATH, len(files)))

--- a/tools/source/dumptools/dump_scripts/hidden_items.py
+++ b/tools/source/dumptools/dump_scripts/hidden_items.py
@@ -4,10 +4,14 @@ import re
 import struct
 from pathlib import Path
 
+from dump_scripts.dump_tools import read_arm9_table
+
 
 ITEM_DEFINE_RE = re.compile(r"^#define\s+(ITEM_[A-Z0-9_]+)\s+(\d+)\b")
 HIDDEN_ITEM_STRUCT = struct.Struct("<HBBHH")
-INPUT_PATH = Path("build/a028/8_18")
+ARM9_HIDDEN_ITEMS_OFFSET = 0xFA558
+HIDDEN_ITEM_COUNT = 231
+INPUT_PATH = Path("base/arm9.bin")
 ITEMS_PATH = Path("include/constants/item.h")
 OUTPUT_PATH = Path("dumped_c/HiddenItems.c")
 
@@ -31,6 +35,15 @@ def parse_hidden_item_binary(data: bytes, input_name: str) -> list[tuple[int, in
         item_id, quantity, unk3, unk4, index = HIDDEN_ITEM_STRUCT.unpack_from(data, offset)
         rows.append((item_id, quantity, unk3, unk4, index))
     return rows
+
+
+def read_hidden_items_from_arm9(arm9_data: bytes) -> bytes:
+    table_size = HIDDEN_ITEM_STRUCT.size * HIDDEN_ITEM_COUNT
+    return read_arm9_table(arm9_data, ARM9_HIDDEN_ITEMS_OFFSET, table_size)
+
+
+def dump_hidden_items_from_arm9_c(arm9_data: bytes, output_items_path: Path = ITEMS_PATH) -> str:
+    return dump_hidden_items_c(read_hidden_items_from_arm9(arm9_data), output_items_path, "arm9 hidden item table")
 
 
 def dump_hidden_items_c(data: bytes, output_items_path: Path = ITEMS_PATH, input_name: str = "hidden item data") -> str:
@@ -70,7 +83,7 @@ def dump_hidden_items(input_path: Path, output_items_path: Path, output_path: Pa
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with output_path.open("w", encoding="utf-8") as output:
-        output.write(dump_hidden_items_c(input_path.read_bytes(), output_items_path, str(input_path)))
+        output.write(dump_hidden_items_from_arm9_c(input_path.read_bytes(), output_items_path))
 
 
 def main() -> None:

--- a/tools/source/dumptools/dump_scripts/hidden_items.py
+++ b/tools/source/dumptools/dump_scripts/hidden_items.py
@@ -22,10 +22,9 @@ def load_item_id_to_name(constants_path: Path) -> dict[int, str]:
     return items
 
 
-def parse_hidden_item_binary(input_path: Path) -> list[tuple[int, int, int, int, int]]:
-    data = input_path.read_bytes()
+def parse_hidden_item_binary(data: bytes, input_name: str) -> list[tuple[int, int, int, int, int]]:
     if len(data) % HIDDEN_ITEM_STRUCT.size != 0:
-        raise ValueError(f"{input_path} size is not a multiple of {HIDDEN_ITEM_STRUCT.size}")
+        raise ValueError(f"{input_name} size is not a multiple of {HIDDEN_ITEM_STRUCT.size}")
 
     rows = []
     for offset in range(0, len(data), HIDDEN_ITEM_STRUCT.size):
@@ -34,11 +33,9 @@ def parse_hidden_item_binary(input_path: Path) -> list[tuple[int, int, int, int,
     return rows
 
 
-def dump_hidden_items(input_path: Path, output_items_path: Path, output_path: Path) -> None:
-    reference_rows = parse_hidden_item_binary(input_path)
+def dump_hidden_items_c(data: bytes, output_items_path: Path = ITEMS_PATH, input_name: str = "hidden item data") -> str:
+    reference_rows = parse_hidden_item_binary(data, input_name)
     output_item_id_to_name = load_item_id_to_name(output_items_path)
-
-    output_path.parent.mkdir(parents=True, exist_ok=True)
     translated_rows = []
 
     for item_id, quantity, unk3, unk4, index in reference_rows:
@@ -47,24 +44,33 @@ def dump_hidden_items(input_path: Path, output_items_path: Path, output_path: Pa
 
     name_width = max(len(row[0]) for row in translated_rows)
 
+    output_lines = [
+        '#include "../include/constants/item.h"\n',
+        '#include "../include/types.h"\n\n',
+        "typedef struct HiddenItemData {\n",
+        "    u16 itemId;\n",
+        "    u8 quantity;\n",
+        "    u8 unk3;\n",
+        "    u16 unk4;\n",
+        "    u16 index;\n",
+        "} HiddenItemData;\n\n",
+        "const HiddenItemData sHiddenItemParam[] = {\n",
+    ]
+
+    for item_name, quantity, unk3, unk4, index in translated_rows:
+        output_lines.append(
+            f"    {{ {item_name:<{name_width}}, {quantity}, {unk3}, {unk4}, {index:<3} }},\n"
+        )
+
+    output_lines.append("};\n\n")
+    return "".join(output_lines)
+
+
+def dump_hidden_items(input_path: Path, output_items_path: Path, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
     with output_path.open("w", encoding="utf-8") as output:
-        output.write('#include "../include/constants/item.h"\n')
-        output.write('#include "../include/types.h"\n\n')
-        output.write("typedef struct HiddenItemData {\n")
-        output.write("    u16 itemId;\n")
-        output.write("    u8 quantity;\n")
-        output.write("    u8 unk3;\n")
-        output.write("    u16 unk4;\n")
-        output.write("    u16 index;\n")
-        output.write("} HiddenItemData;\n\n")
-        output.write("const HiddenItemData sHiddenItemParam[] = {\n")
-
-        for item_name, quantity, unk3, unk4, index in translated_rows:
-            output.write(
-                f"    {{ {item_name:<{name_width}}, {quantity}, {unk3}, {unk4}, {index:<3} }},\n"
-            )
-
-        output.write("};\n\n")
+        output.write(dump_hidden_items_c(input_path.read_bytes(), output_items_path, str(input_path)))
 
 
 def main() -> None:

--- a/tools/source/dumptools/dump_scripts/speciesdata.py
+++ b/tools/source/dumptools/dump_scripts/speciesdata.py
@@ -1,4 +1,5 @@
 import io
+from collections import defaultdict
 
 import dump_scripts.dump_tools as dump_tools
 from dump_scripts.dump_tools import *
@@ -99,6 +100,11 @@ def get_text_or_default(lines, index, default):
     return default
 
 
+def get_max_species_including_forms():
+    max_species = dump_tools.parse_c_header_defines("include/constants/species.h", "MAX_SPECIES_INCLUDING_FORMS")
+    return next(iter(max_species.keys()))
+
+
 def _read_metric_values(data, width, signed):
     values = []
     for offset in range(0, len(data), width):
@@ -130,7 +136,10 @@ def dump_species_data(mondata_narc, msgdata_narc, pokedexsort_narc=None):
         mondata_narc = parse_mondata_files(mondata_narc.files)
 
     text_banks = decode_mon_text_banks(msgdata_narc)
-    metrics_by_species = decode_species_metrics(pokedexsort_narc, len(mondata_narc))
+    species_count = max(len(mondata_narc), get_max_species_including_forms() + 1)
+    if len(mondata_narc) < species_count:
+        mondata_narc.extend(defaultdict(int) for _ in range(species_count - len(mondata_narc)))
+    metrics_by_species = decode_species_metrics(pokedexsort_narc, species_count)
 
     lines = [
         '#include "../include/species_data.h"',

--- a/tools/source/dumptools/dump_scripts/trainerdata.py
+++ b/tools/source/dumptools/dump_scripts/trainerdata.py
@@ -163,6 +163,13 @@ def battle_type_expr(value):
     return "DOUBLE_BATTLE" if value != 0 else "SINGLE_BATTLE"
 
 
+def party_size_expr(value):
+    party_size = value & TRAINER_PARTY_SIZE_MASK
+    if value & TRAINER_RANDOM_PARTY_ORDER_FLAG:
+        return f"TRAINER_DATA_RANDOM_PARTY_ORDER | {party_size}"
+    return str(party_size)
+
+
 def ability_slot_expr(value):
     return ABILITY_SLOT_NAMES.get(value, str(value))
 
@@ -274,6 +281,8 @@ def dump_trainerdata_c(rom, msgdata_narc, expanded):
         lines.append("        .data = {")
         lines.append(f"            .trainerType = {trainer_type_expr(trainer['flags'])},")
         lines.append(f"            .trainerClass = {lookup_const('TRAINERCLASS', trainer['class'])},")
+        if trainer["num_pokemon"] & TRAINER_RANDOM_PARTY_ORDER_FLAG:
+            lines.append(f"            .partySize = {party_size_expr(trainer['num_pokemon'])},")
         lines.append(
             "            .items = { "
             + ", ".join(

--- a/tools/source/trainerdatagen/trainer_data_gen.c
+++ b/tools/source/trainerdatagen/trainer_data_gen.c
@@ -159,7 +159,7 @@ static void WriteTrainerHeaderMember(const char *dir, int index, const TrainerDa
 
     data[0x00] = entry->data.trainerType;
     WriteLe16(&data[0x01], entry->data.trainerClass);
-    data[0x03] = (uint8_t)partyCount;
+    data[0x03] = (uint8_t)((entry->data.partySize & TRAINER_DATA_RANDOM_PARTY_ORDER) | partyCount);
     for (i = 0; i < 4; i++) {
         WriteLe16(&data[0x04 + (i * 2)], entry->data.items[i]);
     }


### PR DESCRIPTION
- wrap each dump in a try/catch
- hidden items further standardized
- fix for dumping species when not all species were present in base (i.e. new megas and such were added)
- fix for dumping trainers with randomized order
- fix headbutt dump

failure looks like:
```
Failed to dump Moves.c: 'Unknown key: a/9/9/9'
Completed with 1 failed dump(s): Moves.c
make[1]: *** [dump_narc_data] Error 1
make: *** [dumprom] Error 2
```

but still outputs the other files