### PR TITLE
fix: change the form to the default form

### DIFF
--- a/data/Evolutions.c
+++ b/data/Evolutions.c
@@ -11132,7 +11132,7 @@ const EvolutionTable __data[MAX_SPECIES_INCLUDING_FORMS + 1] =
 
     [SPECIES_ROCKRUFF] = {
         .entries = {
-            { EVO_LEVEL_DAY, 25, MON_WITH_FORM(SPECIES_LYCANROC, 3) },
+            { EVO_LEVEL_DAY, 25, SPECIES_LYCANROC },
             { EVO_LEVEL_NIGHT, 25, MON_WITH_FORM(SPECIES_LYCANROC, 1) },
             { EVO_NONE, 0, SPECIES_NONE },
             { EVO_NONE, 0, SPECIES_NONE },


### PR DESCRIPTION
I don't know, I was having some troubles with this
I understand that the form 3 doesn't exists, we have just mapped 0 forms and the defualt form (the form 0).

0 Default = Lycanroc Midday Form
1 Default = Lycanroc Midnight Form
2 Default = Lycanroc Dusk Form

I can be wrong, if it's the case just close this PR :sob: 