### PR TITLE
Fix out-of-bounds read in ov12_0224DD74 for move IDs above 467

### DIFF
--- a/src/battle/battle_controller_player.c
+++ b/src/battle/battle_controller_player.c
@@ -228,7 +228,9 @@ void LONG_CALL ov12_0224DD74(struct BattleSystem *bsys UNUSED, struct BattleStru
     int moveType = GetAdjustedMoveType(ctx, ctx->attack_client, ctx->current_move_index);
 
     // Update Mirror Move vars.
-    if (ctx->aiWorkTable.old_moveTbl[ctx->moveNoTemp].flag & FLAG_MIRROR_MOVE
+    // old_moveTbl is the vanilla AI's table, declared [467 + 1]; expanded move
+    // ids index past it. moveTbl is the full-size table used everywhere else.
+    if (ctx->moveTbl[ctx->moveNoTemp].flag & FLAG_MIRROR_MOVE
     && !(ctx->server_status_flag & BATTLE_STATUS_NO_MOVE_SET)
     && ctx->defence_client != BATTLER_NONE
     && ctx->server_status_flag2 & BATTLE_STATUS2_DISPLAY_ATTACK_MESSAGE)
@@ -267,7 +269,7 @@ void LONG_CALL ov12_0224DD74(struct BattleSystem *bsys UNUSED, struct BattleStru
 
             if (ctx->server_status_flag2 & BATTLE_STATUS2_MOVE_SUCCEEDED && !(ctx->waza_status_flag & MOVE_STATUS_FLAG_FAILED))
             {
-                switch (ctx->aiWorkTable.old_moveTbl[ctx->current_move_index].target)
+                switch (ctx->moveTbl[ctx->current_move_index].target)
                 {
                     case RANGE_USER:
                     case RANGE_USER_SIDE:


### PR DESCRIPTION
## The bug

`ov12_0224DD74` in `src/battle/battle_controller_player.c` reads move data out of `ctx->aiWorkTable.old_moveTbl` in two places:

```c
if (ctx->aiWorkTable.old_moveTbl[ctx->moveNoTemp].flag & FLAG_MIRROR_MOVE
switch (ctx->aiWorkTable.old_moveTbl[ctx->current_move_index].target)
```

`old_moveTbl` is declared `struct BattleMove old_moveTbl[467 + 1]` in `include/battle.h` — sized for the vanilla move count, since it sits at a fixed offset inside `BattleAIWorkTable`. But `moveNoTemp` and `current_move_index` are real move IDs, which in this engine go up to `NUM_OF_MOVES`. Anything from 468 upward indexes past the end of that array and into whatever `BattleAIWorkTable` field follows it, then interprets those bytes as a `BattleMove`'s `flag` and `target`.

I think this is just a straggler from the table expansion. `git log -S 'NUM_OF_MOVES + 1' -- include/battle.h` points at the commit that added `moveTbl[NUM_OF_MOVES + 1]` and repointed `DumpMoveTableData` at it. Every other consumer in the battle engine was moved over, but this one function — being decompiled vanilla code, named after its address — kept reading the old vanilla-sized table and got missed.

Worth noting `old_moveTbl` has no writer anywhere in the tree either. Grepping the whole repo, the only two references to it are these two reads.

## Impact

Two things go wrong for any move with an ID above 467, which is most of the post-Gen-4 movepool:

- The `FLAG_MIRROR_MOVE` test reads a garbage flag, so Mirror Move's "can this be copied" tracking is decided by unrelated battle state.
- The `switch` on `.target` is what maintains `lastClientDamagingMove` / `lastClientDamagedBy`, which Counter, Mirror Coat and Metal Burst read to decide what to hit back. With a garbage `target` the wrong branch is taken and that bookkeeping is wrong.

It reads rather than writes, so it doesn't corrupt anything — but the values it produces depend on unrelated struct contents, which makes those moves behave inconsistently.

## The fix

Point both reads at `moveTbl`, which is `[NUM_OF_MOVES + 1]`, is filled once per battle by `DumpMoveTableData` in `ServerInit`, and is what the rest of the engine already uses. Same element type, so it's a drop-in change.

I left a short comment so the next person doesn't "restore" the old table thinking it's the intended one.

I don't have a way to test the Counter/Mirror Coat path on hardware right now, so a sanity check from someone who can set up a battle with a high-ID move and Mirror Move would be worth doing before this is merged.