### PR TITLE
Item data table is allocated one entry short

### DIFF
--- a/src/item.c
+++ b/src/item.c
@@ -499,7 +499,8 @@ void *LONG_CALL ItemDataTableLoad(int heapID)
 {
     int max;
 
-    max = GetItemIndex(MAX_TOTAL_ITEM_NUM, ITEM_GET_DATA);
+    // MAX_TOTAL_ITEM_NUM is the last valid item id, so the table needs id + 1 entries
+    max = GetItemIndex(MAX_TOTAL_ITEM_NUM, ITEM_GET_DATA) + 1;
 
     return AllocAndReadFromNarcMemberByIdPair(ARC_ITEM_DATA, 0, heapID, 0, sizeof(ITEMDATA) * max); // 800757Ch
 }


### PR DESCRIPTION
## The bug

`ItemDataTableLoad` in `src/item.c`:

```c
max = GetItemIndex(MAX_TOTAL_ITEM_NUM, ITEM_GET_DATA);
return AllocAndReadFromNarcMemberByIdPair(ARC_ITEM_DATA, 0, heapID, 0, sizeof(ITEMDATA) * max);
```

`MAX_TOTAL_ITEM_NUM` is the ID of the last item, not a count — `include/constants/item.h` says as much where it's defined ("must name the LAST custom item so the item data table is sized to include them"). `GetItemIndex(..., ITEM_GET_DATA)` passes it straight through for anything that isn't `ITEM_DUMMY_ID` / `ITEM_RETURN_ID`, so `max` ends up being the last ID rather than the number of entries.

The table therefore covers IDs `0 .. MAX_TOTAL_ITEM_NUM - 1`, and the very last item's data sits one `ITEMDATA` past the end of the allocation.

The NARC itself is fine — `data/itemdata/itemdata.c` has a designated entry for the last item, and `o2narc` splits the blob into one member per `sizeof(ITEMDATA)`, so the data is there. It just never gets copied into the runtime table.

## Impact

Any lookup of the last item ID reads one struct past the heap buffer. That includes `fieldUseFunc` and `battleUseFunc`, which are used as indices into function tables — so a garbage value there doesn't just give wrong item stats, it can dispatch through the wrong entry.

On stock hg-engine the last item is `ITEM_CANARI_BREAD`, which most players will never have, so this is easy to miss. It gets much more likely to be hit in a hack that adds custom items on the end, since whatever ends up last is the one that reads out of bounds — that's how I ran into it.

## The fix

Allocate `max + 1` entries. One extra `ITEMDATA` (36 bytes), and it reads a NARC member that provably exists, so there's no risk of running past the end of the file.