### PR TITLE
GetItemDescIntoString doesn't check NewMsgDataFromNarc for NULL

### DIFF
--- a/src/item.c
+++ b/src/item.c
@@ -491,8 +491,10 @@ void LONG_CALL GetItemDescIntoString(String *dest, u16 itemId, u16 heapId)
         : MSG_DATA_ITEM_FILE(MSG_DATA_ITEM_DESCRIPTION_GEN4, gen);
     MsgData *msgData = NewMsgDataFromNarc(MSGDATA_LOAD_LAZY, ARC_MSG_DATA, fileId, heapId);
     u32 offset = ITEM_MSG_OFFSET(itemId);
-    ReadMsgDataIntoString(msgData, offset, dest);
-    DestroyMsgData(msgData);
+    if (msgData != NULL) {
+        ReadMsgDataIntoString(msgData, offset, dest);
+        DestroyMsgData(msgData);
+    }
 }
 
 void *LONG_CALL ItemDataTableLoad(int heapID)


### PR DESCRIPTION
## The bug

`GetItemDescIntoString` in `src/item.c` uses the result of `NewMsgDataFromNarc` without checking it:

```c
MsgData *msgData = NewMsgDataFromNarc(MSGDATA_LOAD_LAZY, ARC_MSG_DATA, fileId, heapId);
u32 offset = ITEM_MSG_OFFSET(itemId);
ReadMsgDataIntoString(msgData, offset, dest);
DestroyMsgData(msgData);
```

`BufferOffsetItemLineFromFile` in `src/message.c` makes the same call against the same archive and does guard it:

```c
if (msgData != NULL) {
    ReadMsgDataIntoString(msgData, offset, msgFmt->buffer);
    ...
}
```

So the NULL case is already understood to be possible — this call site just doesn't handle it.

## Impact

If the allocation or the lazy load fails, the next line dereferences NULL and the game dies. `GetItemDescIntoString` is hooked over `02077D64` and runs any time an item description is shown (bag, PC, mart), so it's a fairly common path — though obviously it only bites when memory is tight.

I haven't reproduced a failure; this is a missing guard rather than something I saw crash.

## The fix

Same guard as the sibling function. On the normal path nothing changes; if `msgData` comes back NULL, the description is left alone instead of crashing. The function returns `void` and is a full-function hook, so skipping the write doesn't break any caller contract.