### PR TITLE
Rock Smash quality loop is bounded by the odds table's length

### DIFF
--- a/src/field/rock_smash_item.c
+++ b/src/field/rock_smash_item.c
@@ -80,7 +80,7 @@ u32 DetermineRockSmashItem(u32 tableIndex, u32 quality)
             ability = NUM_ABILITIES;
         }
 
-        for (u32 i = 0; i < NELEMS(RockSmashAbilityOddsTable); i++) {
+        for (u32 i = 0; i < NELEMS(RockSmashAbilityQualityTable); i++) {
             if (ability == RockSmashAbilityQualityTable[i].ability) {
                 quality += RockSmashAbilityQualityTable[i].quality;
                 break;


### PR DESCRIPTION
## The bug

In `DetermineRockSmashItem` (`src/field/rock_smash_item.c`):

```c
for (u32 i = 0; i < NELEMS(RockSmashAbilityOddsTable); i++) {
    if (ability == RockSmashAbilityQualityTable[i].ability) {
        quality += RockSmashAbilityQualityTable[i].quality;
        break;
    }
}
```

The loop bound comes from `RockSmashAbilityOddsTable` (3 entries: Suction Cups, Magnet Pull, Keen Eye) but the body indexes `RockSmashAbilityQualityTable` (2 entries: Serene Grace, Super Luck). Looks like a copy-paste from the odds loop further down in `CheckRockSmashItemDrop`, which is correctly bounded against its own table.

## Impact

Unless the lead's ability is Serene Grace or Super Luck — in which case the `break` fires first — the third iteration reads one struct past the end of `RockSmashAbilityQualityTable` and compares the ability against whatever constant data the linker put after it.

It's a read from rodata, so nothing gets corrupted and it won't crash. The practical effect is that the quality bonus depends on link order: if that garbage ever happens to equal the lead's ability ID, you'd get a bonus you shouldn't. Low severity, but it runs on every Rock Smash item roll.

## The fix

Bound the loop by the table it actually indexes. The odds loop in `CheckRockSmashItemDrop` is already correct and isn't touched.