### PR TITLE
ItemToMachineMove bounds check uses sizeof instead of the element count

### DIFF
--- a/src/item.c
+++ b/src/item.c
@@ -546,7 +546,7 @@ u16 ItemToMachineMove(u16 itemId)
     }
 
     u16 index = ItemToMachineMoveIndex(itemId);
-    if (index >= sizeof(sMachineMoves) + 1) {
+    if (index >= NELEMS(sMachineMoves)) {
         return MOVE_NONE;
     }
     return sMachineMoves[index];


### PR DESCRIPTION
## The bug

`src/item.c`:

```c
u16 index = ItemToMachineMoveIndex(itemId);
if (index >= sizeof(sMachineMoves) + 1) {
    return MOVE_NONE;
}
return sMachineMoves[index];
```

`sMachineMoves` is a `u16` array, so `sizeof` is twice the element count. The guard rejects at ~681 when the array only has 340 entries, i.e. it permits roughly double the valid range.

## Impact

Nothing today. I traced every branch of `ItemToMachineMoveIndex` and the highest index it can return is 339, so the check never actually fires and no out-of-bounds read happens in the current tree.

I'm sending it because the guard is inert rather than protective — it looks like a bounds check but doesn't function as one. The moment someone adds another machine item range without growing `sMachineMoves` by exactly the same amount, this silently reads past the array instead of returning `MOVE_NONE`. That's an easy mistake to make in a codebase that's actively expanding the item space.

## The fix

Use `NELEMS`, which is already the idiom elsewhere in this file. No behaviour change today — it just makes the existing check do what it looks like it does.