### PR TITLE
HandleLoadOverlay matches a priority-list row but unloads from row 0

### DIFF
--- a/src/overlay.c
+++ b/src/overlay.c
@@ -117,9 +117,9 @@ loadExtension:
             for (u32 j = 1; j < NELEMS(gOverlayPriorityList[0]); j++)
             {
 #ifdef DEBUG_PRINT_OVERLAY_LOADS
-                debug_printf("Overlay %d has priority over overlay %d--unloading the latter...\n", ovyId, gOverlayPriorityList[0][j]);
+                debug_printf("Overlay %d has priority over overlay %d--unloading the latter...\n", ovyId, gOverlayPriorityList[i][j]);
 #endif // DEBUG_PRINT_OVERLAY_LOADS
-                UnloadOverlayByID(gOverlayPriorityList[0][j]);
+                UnloadOverlayByID(gOverlayPriorityList[i][j]);
             }
         }
     }


### PR DESCRIPTION
## The bug

In `HandleLoadOverlay` (`src/overlay.c`):

```c
for (i = 0; i < NELEMS(gOverlayPriorityList); i++) {
    if (gOverlayPriorityList[i][0] == ovyId) {
        for (u32 j = 1; j < NELEMS(gOverlayPriorityList[0]); j++) {
            ...
            UnloadOverlayByID(gOverlayPriorityList[0][j]);
        }
    }
}
```

The outer loop finds the matching row with `[i][0]`, but the inner loop then unloads `[0][j]` instead of `[i][j]`. The `debug_printf` just above it has the same `[0]`.

## Impact

None right now — `gOverlayPriorityList` has exactly one row, so when the match succeeds `i` is always 0 and `[0][j]` happens to be correct.

It breaks as soon as a second row is added: matching row 1 would unload row 0's overlays and leave row 1's alone. Given the table is clearly built to hold more than one entry (the `NELEMS` scaffolding is all there), it seemed worth fixing before someone adds a row and spends a while wondering why their priority entry does nothing.

## The fix

Use `[i][j]` in both places. No behaviour change with the table as it stands.