### PR TITLE
Fix OOB error with rock smash quality table

### DIFF
--- a/src/field/rock_smash_item.c
+++ b/src/field/rock_smash_item.c
@@ -54,7 +54,6 @@ const RockSmashAbilityOdds RockSmashAbilityOddsTable[] = {
 
 // List of abilities that increase the quality of items received from a rock and their increase amounts.
 // Note: Having any of these abilities active will prevent items of the lowest quality from appearing at all!
-// CURRENTLY DOES NOTHING. TODO: check this via bytereplacement.
 const RockSmashAbilityQuality RockSmashAbilityQualityTable[] = {
     { ABILITY_SERENE_GRACE, 1 },
     { ABILITY_SUPER_LUCK,   1 },
@@ -80,7 +79,7 @@ u32 DetermineRockSmashItem(u32 tableIndex, u32 quality)
             ability = NUM_ABILITIES;
         }
 
-        for (u32 i = 0; i < NELEMS(RockSmashAbilityOddsTable); i++) {
+        for (u32 i = 0; i < NELEMS(RockSmashAbilityQualityTable); i++) {
             if (ability == RockSmashAbilityQualityTable[i].ability) {
                 quality += RockSmashAbilityQualityTable[i].quality;
                 break;


### PR DESCRIPTION
For some reason said error caused the quality boost to be always active.