### PR TITLE
Future Sight vs Protect/Endure

### DIFF
--- a/data/battle_tests/moves/future_sight/endure_and_protect.c
+++ b/data/battle_tests/moves/future_sight/endure_and_protect.c
@@ -1,4 +1,4 @@
-// Test: Future Sight - not blocked protect, triggers endure
+// Test: Future Sight - not blocked by protect, triggers endure
 #ifndef GET_TEST_CASE_ONLY
 
 #include "../../../../include/battle.h"
@@ -120,10 +120,12 @@ const struct TestBattleScenario BattleTests[] = {
         },
         .expectations = {
             { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "Gardevoir foresaw an attack!" },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "The opposing Archaludon protected itself!" },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "The opposing Toxapex used Endure!" },
             { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "The opposing Archaludon took the Future Sight attack!" },
-            { .expectationType = EXPECTATION_TYPE_HP_BAR, .battlerIDOrPartySlot = BATTLER_ENEMY_FIRST, .expectationValue.hpTaken = { 131, 133, 134, 135, 136, 139, 140, 142, 143, 144, 147, 148, 149, 151, 152, 155 } },
             { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "Delphox lost some of its HP!" },
             { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "The opposing Toxapex took the Future Sight attack!" },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "It’s super effective!" },
             { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "The opposing Toxapex endured the hit!" },
         },
     },

--- a/data/battle_tests/moves/future_sight/endure_and_protect.c
+++ b/data/battle_tests/moves/future_sight/endure_and_protect.c
@@ -1,0 +1,133 @@
+// Test: Future Sight - not blocked protect, triggers endure
+#ifndef GET_TEST_CASE_ONLY
+
+#include "../../../../include/battle.h"
+#include "../../../../include/constants/ability.h"
+#include "../../../../include/constants/item.h"
+#include "../../../../include/constants/moves.h"
+#include "../../../../include/constants/species.h"
+#include "../../../../include/test_battle.h"
+
+const struct TestBattleScenario BattleTests[] = {
+
+#endif
+
+    {
+        .battleType = BATTLE_TYPE_DOUBLES,
+        .weather = FIELD_CONDITION_NONE,
+        .fieldCondition = 0,
+        .terrain = PSYCHIC_TERRAIN,
+        .playerParty = {
+            {
+                .species = SPECIES_DELPHOX,
+                .level = 50,
+                .form = 0,
+                .ability = ABILITY_BLAZE,
+                .item = ITEM_LIFE_ORB,
+                .moves = { MOVE_FUTURE_SIGHT, MOVE_NONE, MOVE_NONE, MOVE_NONE },
+                .hp = FULL_HP,
+                .status = 0,
+                .condition2 = 0,
+                .moveEffectFlags = 0,
+            },
+            {
+                .species = SPECIES_GARDEVOIR,
+                .level = 50,
+                .form = 0,
+                .ability = ABILITY_TELEPATHY,
+                .item = ITEM_NONE,
+                .moves = { MOVE_FUTURE_SIGHT, MOVE_NONE, MOVE_NONE, MOVE_NONE },
+                .hp = FULL_HP,
+                .status = 0,
+                .condition2 = 0,
+                .moveEffectFlags = 0,
+            },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE } },
+        .enemyParty = {
+            {
+                .species = SPECIES_ARCHALUDON,
+                .level = 70,
+                .form = 0,
+                .ability = ABILITY_STAMINA,
+                .item = MOVE_NONE,
+                .moves = { MOVE_SLEEP_TALK, MOVE_PROTECT, MOVE_NONE, MOVE_NONE },
+                .hp = FULL_HP,
+                .status = 0,
+                .condition2 = 0,
+                .moveEffectFlags = 0,
+            },
+            {
+                .species = SPECIES_TOXAPEX,
+                .level = 5,
+                .form = 0,
+                .ability = ABILITY_TORRENT,
+                .item = ITEM_FOCUS_SASH,
+                .moves = { MOVE_SLEEP_TALK, MOVE_ENDURE, MOVE_NONE, MOVE_NONE },
+                .hp = FULL_HP,
+                .status = 0,
+                .condition2 = 0,
+                .moveEffectFlags = 0,
+            },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE },
+            { .species = SPECIES_NONE } },
+        .playerScript = {
+            {
+                  { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_FIRST },
+                  { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_FIRST },
+                  { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_FIRST },
+                  { ACTION_NONE, 0 },
+                  { ACTION_NONE, 0 },
+                  { ACTION_NONE, 0 },
+                  { ACTION_NONE, 0 },
+                  { ACTION_NONE, 0 },
+              },
+            {
+                { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_SECOND },
+                { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_SECOND },
+                { ACTION_MOVE_SLOT_1, BATTLER_ENEMY_SECOND },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            } },
+        .enemyScript = {
+            {
+                 { ACTION_MOVE_SLOT_1, BATTLER_PLAYER_FIRST },
+                 { ACTION_MOVE_SLOT_1, BATTLER_PLAYER_FIRST },
+                 { ACTION_MOVE_SLOT_2, BATTLER_PLAYER_FIRST },
+                 { ACTION_NONE, 0 },
+                 { ACTION_NONE, 0 },
+                 { ACTION_NONE, 0 },
+                 { ACTION_NONE, 0 },
+                 { ACTION_NONE, 0 },
+             },
+            {
+                { ACTION_MOVE_SLOT_1, BATTLER_PLAYER_FIRST },
+                { ACTION_MOVE_SLOT_1, BATTLER_PLAYER_FIRST },
+                { ACTION_MOVE_SLOT_2, BATTLER_PLAYER_FIRST },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+                { ACTION_NONE, 0 },
+            }
+        },
+        .expectations = {
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "Gardevoir foresaw an attack!" },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "The opposing Archaludon took the Future Sight attack!" },
+            { .expectationType = EXPECTATION_TYPE_HP_BAR, .battlerIDOrPartySlot = BATTLER_ENEMY_FIRST, .expectationValue.hpTaken = { 131, 133, 134, 135, 136, 139, 140, 142, 143, 144, 147, 148, 149, 151, 152, 155 } },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "Delphox lost some of its HP!" },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "The opposing Toxapex took the Future Sight attack!" },
+            { .expectationType = EXPECTATION_TYPE_MESSAGE, .expectationValue.message = "The opposing Toxapex endured the hit!" },
+        },
+    },
+#ifndef GET_TEST_CASE_ONLY
+};
+// each test file is a separate .c file in battle_tests/ for better organization
+#endif

--- a/src/individual/BattleController_BeforeMove.c
+++ b/src/individual/BattleController_BeforeMove.c
@@ -2553,6 +2553,7 @@ BOOL CheckProtectedBySelf(struct BattleStruct *ctx, int defender, u16 *protected
 BOOL BattleController_CheckProtect(struct BattleSystem *bsys, struct BattleStruct *ctx, int defender)
 {
     if (ctx->oneTurnFlag[defender].protectFlag
+        && !ctx->futureSightHitTurn
         && !CanHitThroughProtect(ctx, ctx->attack_client, defender)) {
         BOOL protectedByAlly = FALSE;
         BOOL protectedBySelf = FALSE;

--- a/src/individual/CalcBaseDamage.c
+++ b/src/individual/CalcBaseDamage.c
@@ -146,6 +146,10 @@ int UNUSED CalcBaseDamageInternal(struct BattleSystem *bw, struct BattleStruct *
     case MOVE_HEAVY_SLAM:
     case MOVE_HEAT_CRASH:
         switch (AttackingMon.weight / DefendingMon.weight) {
+        case 0:
+        case 1:
+            movepower = 40;
+            break;
         case 2:
             movepower = 60;
             break;
@@ -156,11 +160,8 @@ int UNUSED CalcBaseDamageInternal(struct BattleSystem *bw, struct BattleStruct *
             movepower = 100;
             break;
         case 5:
-            movepower = 120;
-            break;
-        // less than 2
         default:
-            movepower = 40;
+            movepower = 120;
             break;
         }
         break;

--- a/src/individual/CalcBaseDamage.c
+++ b/src/individual/CalcBaseDamage.c
@@ -145,6 +145,10 @@ int UNUSED CalcBaseDamageInternal(struct BattleSystem *bw, struct BattleStruct *
         break;
     case MOVE_HEAVY_SLAM:
     case MOVE_HEAT_CRASH:
+        if (DefendingMon.weight == 0) {
+            movepower = 120;
+            break;
+        }
         switch (AttackingMon.weight / DefendingMon.weight) {
         case 0:
         case 1:


### PR DESCRIPTION
The opposing Archaludon used Protect!
The opposing Archaludon protected itself!
The opposing Toxapex used Endure!
The opposing Toxapex braced itself!
Delphox used Future Sight!
But it failed!
Gardevoir used Future Sight!
But it failed!
The opposing Archaludon took the Future Sight attack! 
[Move 248     Damage -68]
It’s not very effective...
Archaludon’s Stamina
The opposing Archaludon’s Defense rose!
Delphox lost some of its HP!
The opposing Toxapex took the Future Sight attack!
[Move 248     Damage -20]
It’s super effective!
The opposing Toxapex endured the hit!